### PR TITLE
Add travis config for Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 
 os:
   - linux
-  - osx
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+
+php:
+  - '7.1'
+
+env:
+  - VALIDATION=false
+  - VALIDATION=true
+
+os:
+  - linux
+  - osx
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - VALIDATION=true
+
+cache:
+  directories:
+    - validation/frameworks
+
+before_script:
+  - phpenv config-rm xdebug.ini
+
+script:
+  - if [[ "$VALIDATION" == "true" ]]; then phpunit --testsuite validation; fi
+  - if [[ "$VALIDATION" != "true" ]]; then phpunit --testsuite invariants; fi
+  - if [[ "$VALIDATION" != "true" ]]; then phpunit --testsuite grammar; fi
+  - if [[ "$VALIDATION" != "true" ]]; then phpunit --testsuite api; fi


### PR DESCRIPTION
Part of #9 

Framework validation tests, which take much longer, are run separately from the core test suites. 