### PR TITLE
Use "yield from" in descendant generators

### DIFF
--- a/tests/NodeApiTest.php
+++ b/tests/NodeApiTest.php
@@ -40,7 +40,7 @@ PHP;
     }
 
     public function testRootNodeIsScript() {
-        $treeElements = iterator_to_array(self::$sourceFileNode->getDescendantNodes());
+        $treeElements = iterator_to_array(self::$sourceFileNode->getDescendantNodes(), false);
         array_push($treeElements, self::$sourceFileNode);
 
         foreach($treeElements as $element) {
@@ -49,7 +49,7 @@ PHP;
     }
 
     public function testFileContentsRetrievableFromAnyNode() {
-        $treeElements = iterator_to_array(self::$sourceFileNode->getDescendantNodes());
+        $treeElements = iterator_to_array(self::$sourceFileNode->getDescendantNodes(), false);
         array_push($treeElements, self::$sourceFileNode);
 
         foreach($treeElements as $element) {

--- a/tests/ParserInvariantsTest.php
+++ b/tests/ParserInvariantsTest.php
@@ -76,7 +76,7 @@ class ParserInvariantsTest extends LexerInvariantsTest {
      * @dataProvider sourceFileNodeProvider
      */
     public function testEveryNodeSpanIsSumOfChildSpans($filename, Node $sourceFileNode) {
-        $treeElements = iterator_to_array($sourceFileNode->getDescendantNodesAndTokens());
+        $treeElements = iterator_to_array($sourceFileNode->getDescendantNodesAndTokens(), false);
         array_push($treeElements, $sourceFileNode);
 
         foreach ($treeElements as $element) {
@@ -115,7 +115,7 @@ class ParserInvariantsTest extends LexerInvariantsTest {
      * @dataProvider sourceFileNodeProvider
      */
     public function testEachChildHasExactlyOneParent($filename, Node $sourceFileNode) {
-        $allTreeElements = iterator_to_array($sourceFileNode->getDescendantNodesAndTokens());
+        $allTreeElements = iterator_to_array($sourceFileNode->getDescendantNodesAndTokens(), false);
         array_push($allTreeElements, $sourceFileNode);
 
         foreach ($sourceFileNode->getDescendantNodesAndTokens() as $childWithParent) {
@@ -138,7 +138,7 @@ class ParserInvariantsTest extends LexerInvariantsTest {
      * @dataProvider sourceFileNodeProvider
      */
     public function testEveryChildIsNodeOrTokenType($filename, Node $sourceFileNode) {
-        $treeElements = iterator_to_array($sourceFileNode->getDescendantNodesAndTokens());
+        $treeElements = iterator_to_array($sourceFileNode->getDescendantNodesAndTokens(), false);
         array_push($treeElements, $sourceFileNode);
 
         foreach ($sourceFileNode->getDescendantNodes() as $descendant) {
@@ -164,7 +164,7 @@ class ParserInvariantsTest extends LexerInvariantsTest {
      * @dataProvider sourceFileNodeProvider
      */
     public function testRootNodeIsNeverAChild($filename, Node $sourceFileNode) {
-        $treeElements = iterator_to_array($sourceFileNode->getDescendantNodesAndTokens());
+        $treeElements = iterator_to_array($sourceFileNode->getDescendantNodesAndTokens(), false);
         array_push($treeElements, $sourceFileNode);
 
         foreach($treeElements as $element) {
@@ -180,7 +180,7 @@ class ParserInvariantsTest extends LexerInvariantsTest {
      * @dataProvider sourceFileNodeProvider
      */
     public function testEveryNodeHasAKind($filename, Node $sourceFileNode) {
-        $treeElements = iterator_to_array($sourceFileNode->getDescendantNodes());
+        $treeElements = iterator_to_array($sourceFileNode->getDescendantNodes(), false);
         array_push($treeElements, $sourceFileNode);
 
         foreach($treeElements as $element) {


### PR DESCRIPTION
This required some adjustment to remove the dependence on specific keys, in particular checks for $idx=0 and use of iterator_to_array() with $use_keys=true.

See also discussion in #23.