### PR TITLE
Ignore *.ast files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 vendor/
 composer.lock
 tests/output
+*.ast


### PR DESCRIPTION
- this makes it easier to dogfood the syntax visualizer from this project