### PR TITLE
lint php files on travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ cache:
 
 before_script:
   - phpenv config-rm xdebug.ini
+  - if find . -name "*.php" -path "./src/*" -path "./experiments/*" -path "./tools/*" -path "./syntax-visualizer/server/src/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi  
+  - if find . -name "*.php" -path "./tests/*" -path "./validation/*" -maxdepth 0 --exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi    
 
 script:
   - |


### PR DESCRIPTION
this makes the travis build break when syntax errors are contained in *.php files.

to prevent errors like https://github.com/Microsoft/tolerant-php-parser/pull/62