### PR TITLE
TemplateExpression should extend Expression

### DIFF
--- a/src/Node/Expression/TemplateExpression.php
+++ b/src/Node/Expression/TemplateExpression.php
@@ -6,6 +6,8 @@
 
 namespace Microsoft\PhpParser\Node\Expression;
 
+use Microsoft\PhpParser\Node;
+
 class TemplateExpression extends Node {
     public $children;
 

--- a/src/Node/Expression/TemplateExpression.php
+++ b/src/Node/Expression/TemplateExpression.php
@@ -6,9 +6,9 @@
 
 namespace Microsoft\PhpParser\Node\Expression;
 
-use Microsoft\PhpParser\Node;
+use Microsoft\PhpParser\Node\Expression;
 
-class TemplateExpression extends Node {
+class TemplateExpression extends Expression {
     public $children;
 
 }


### PR DESCRIPTION
_TemplateExpression_ cannot work as it is since it tries to extend the class _Node_ which doesn't exist in the same namespace.
It should extend _Expression_ like all the others classes in the same namespace.