### PR TITLE
fixed syntax error in syntax-visualizer example file

### DIFF
--- a/syntax-visualizer/example/foo.php
+++ b/syntax-visualizer/example/foo.php
@@ -5,3 +5,4 @@ class {
     function A () {
 
     public function B () { }
+}


### PR DESCRIPTION
I guess this was not intentionally added, right?