### PR TITLE
fix fatal error from Lexer

### DIFF
--- a/src/Lexer.php
+++ b/src/Lexer.php
@@ -214,7 +214,7 @@ class Lexer implements ITokenStreamProvider {
                     if ($this->isNameStart($text, $pos, $endOfFilePos)) {
                         $this->scanName($text, $pos, $endOfFilePos);
                         $token = new Token(TokenKind::Name, $fullStart, $start, $pos - $fullStart);
-                        $tokenText = $token->getTextForToken($text);
+                        $tokenText = $token->getText($text);
                         $lowerText = strtolower($tokenText);
                         if ($this->isKeywordOrReservedWordStart($lowerText)) {
                             $token = $this->getKeywordOrReservedWordTokenFromNameToken($token, $lowerText, $text, $pos, $endOfFilePos);


### PR DESCRIPTION
For the given code:
```php
<?php
use Microsoft\PhpParser\Lexer;

$content = '<?php echo PHP_EOL;';
$lexer = new Lexer($content);
$tokens = $lexer->getTokensArray();
```

I got the following error:
```
PHP Fatal error:  Uncaught Error: Call to undefined method Microsoft\PhpParser\Token::getTextForToken() in src/Lexer.php:217
```

Since this class is not used anymore I'm wondering if it should even be kept in the code base.