### PR TITLE
Restricting supported PHP versions to 7.1.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
     "name": "Microsoft/tolerant-php-parser",
     "type": "library",
+    "require": {
+        "php": "7.1.*"
+    },
     "require-dev": {
         "phpunit/phpunit": "^5.5"
     },


### PR DESCRIPTION
Parsing changes with every version, and I'm sure that this package isn't supporting all PHP versions.

Since `.travis.yml` specifies that you are testing against PHP 7.1, the `composer.json` should lock onto `"require":{"php":"7.1.*"}` (and no further, since parsing may change in 7.2)