### PR TITLE
getDescendantNodes: pass predicate recursively

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -157,7 +157,7 @@ class Node implements \JsonSerializable {
             if ($child instanceof Node) {
                 yield $child;
                 if ($shouldDescendIntoChildrenFn == null || $shouldDescendIntoChildrenFn($child)) {
-                    yield from $child->getDescendantNodes();
+                    yield from $child->getDescendantNodes($shouldDescendIntoChildrenFn);
                 }
             }
         }


### PR DESCRIPTION
This PR adds a missing predicate pass down the recursive `getDescendantNodes()` call. That also makes the method consistent with the `getDescendantTokens()` companion. 