### PR TITLE
Lower PHP version to 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.0
+  - 7.1
 
 env:
   - VALIDATION=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 php:
-  - 7.1
+  - 7.0
 
 env:
   - VALIDATION=false


### PR DESCRIPTION
@roblourens The PHP Language Server requires at least PHP 7.0. Raising that to 7.1 would be a breaking change, and I have the suspicion that the reason for the broken build in the tolerant parser PR is a 7.1 feature being used:

```
  [Symfony\Component\Debug\Exception\FatalThrowableError]                      
  Parse error: syntax error, unexpected const (T_CONST), expecting variable (  
  T_VARIABLE) 
```

https://travis-ci.org/felixfbecker/php-language-server/builds/235759632

While 7.1 has many features like nullable types, but I don't think it's worth to do a breaking change for them. It would be great if the parser was able to run on 7.0. It will probably be necessary in the future anyway to test in CI both on lower versions (ignoring tests for parsing newer language features) and on higher versions to test parsing the newest language features.