### PR TITLE
Support nullable types

### DIFF
--- a/src/Node/Expression/AnonymousFunctionCreationExpression.php
+++ b/src/Node/Expression/AnonymousFunctionCreationExpression.php
@@ -35,6 +35,7 @@ class AnonymousFunctionCreationExpression extends Expression {
 
         // FunctionReturnType
         'colonToken',
+        'questionToken',
         'returnType',
 
         // FunctionBody

--- a/src/Node/FunctionReturnType.php
+++ b/src/Node/FunctionReturnType.php
@@ -11,6 +11,8 @@ use Microsoft\PhpParser\Token;
 trait FunctionReturnType {
     /** @var Token */
     public $colonToken;
+    /** @var Token|null */
+    public $questionToken;
     /** @var Token | QualifiedName */
     public $returnType;
 }

--- a/src/Node/MethodDeclaration.php
+++ b/src/Node/MethodDeclaration.php
@@ -29,6 +29,7 @@ class MethodDeclaration extends Node {
 
         // FunctionReturnType
         'colonToken',
+        'questionToken',
         'returnType',
 
         // FunctionBody

--- a/src/Node/Parameter.php
+++ b/src/Node/Parameter.php
@@ -10,23 +10,23 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;
 
 class Parameter extends Node {
+    /** @var Token|null */
+    public $questionToken;
     /** @var QualifiedName | Token | null */
     public $typeDeclaration;
     /** @var Token | null */
     public $byRefToken;
     /** @var Token | null */
     public $dotDotDotToken;
-
     /** @var Token */
     public $variableName;
-
     /** @var Token | null */
     public $equalsToken;
-
     /** @var null | Expression */
     public $default;
 
     const CHILD_NAMES = [
+        'questionToken',
         'typeDeclaration',
         'byRefToken',
         'dotDotDotToken',

--- a/src/Node/Statement/FunctionDeclaration.php
+++ b/src/Node/Statement/FunctionDeclaration.php
@@ -28,6 +28,7 @@ class FunctionDeclaration extends StatementNode implements NamespacedNameInterfa
 
         // FunctionReturnType
         'colonToken',
+        'questionToken',
         'returnType',
 
         // FunctionBody

--- a/tests/cases/parser/abstractMethodDeclaration1.php.tree
+++ b/tests/cases/parser/abstractMethodDeclaration1.php.tree
@@ -65,6 +65,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "kind": "SemicolonToken",

--- a/tests/cases/parser/abstractMethodDeclaration2.php.tree
+++ b/tests/cases/parser/abstractMethodDeclaration2.php.tree
@@ -62,6 +62,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "kind": "SemicolonToken",

--- a/tests/cases/parser/abstractMethodDeclaration3.php.tree
+++ b/tests/cases/parser/abstractMethodDeclaration3.php.tree
@@ -65,6 +65,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/abstractMethodDeclaration4.php.tree
+++ b/tests/cases/parser/abstractMethodDeclaration4.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/abstractMethodDeclaration5.php.tree
+++ b/tests/cases/parser/abstractMethodDeclaration5.php.tree
@@ -64,6 +64,7 @@
                                             "kind": "ColonToken",
                                             "textLength": 1
                                         },
+                                        "questionToken": null,
                                         "returnType": {
                                             "kind": "BoolReservedWord",
                                             "textLength": 4

--- a/tests/cases/parser/abstractMethodDeclaration6.php.tree
+++ b/tests/cases/parser/abstractMethodDeclaration6.php.tree
@@ -69,6 +69,7 @@
                                             "kind": "ColonToken",
                                             "textLength": 1
                                         },
+                                        "questionToken": null,
                                         "returnType": {
                                             "kind": "BoolReservedWord",
                                             "textLength": 4

--- a/tests/cases/parser/abstractMethodDeclaration7.php.tree
+++ b/tests/cases/parser/abstractMethodDeclaration7.php.tree
@@ -61,6 +61,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/anonymousFunctionCreationExpression1.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression1.php.tree
@@ -39,6 +39,7 @@
                             },
                             "anonymousFunctionUseClause": null,
                             "colonToken": null,
+                            "questionToken": null,
                             "returnType": null,
                             "compoundStatementOrSemicolon": {
                                 "CompoundStatementNode": {

--- a/tests/cases/parser/anonymousFunctionCreationExpression10.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression10.php.tree
@@ -82,6 +82,7 @@
                                         "kind": "ColonToken",
                                         "textLength": 1
                                     },
+                                    "questionToken": null,
                                     "returnType": {
                                         "kind": "VoidReservedWord",
                                         "textLength": 4

--- a/tests/cases/parser/anonymousFunctionCreationExpression2.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression2.php.tree
@@ -36,6 +36,7 @@
                             },
                             "anonymousFunctionUseClause": null,
                             "colonToken": null,
+                            "questionToken": null,
                             "returnType": null,
                             "compoundStatementOrSemicolon": {
                                 "CompoundStatementNode": {

--- a/tests/cases/parser/anonymousFunctionCreationExpression3.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression3.php.tree
@@ -33,6 +33,7 @@
                             },
                             "anonymousFunctionUseClause": null,
                             "colonToken": null,
+                            "questionToken": null,
                             "returnType": null,
                             "compoundStatementOrSemicolon": {
                                 "CompoundStatementNode": {

--- a/tests/cases/parser/anonymousFunctionCreationExpression4.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression4.php.tree
@@ -40,6 +40,7 @@
                             },
                             "anonymousFunctionUseClause": null,
                             "colonToken": null,
+                            "questionToken": null,
                             "returnType": null,
                             "compoundStatementOrSemicolon": {
                                 "CompoundStatementNode": {

--- a/tests/cases/parser/anonymousFunctionCreationExpression5.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression5.php.tree
@@ -53,6 +53,7 @@
                                     },
                                     "anonymousFunctionUseClause": null,
                                     "colonToken": null,
+                                    "questionToken": null,
                                     "returnType": null,
                                     "compoundStatementOrSemicolon": {
                                         "CompoundStatementNode": {

--- a/tests/cases/parser/anonymousFunctionCreationExpression6.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression6.php.tree
@@ -53,6 +53,7 @@
                                     },
                                     "anonymousFunctionUseClause": null,
                                     "colonToken": null,
+                                    "questionToken": null,
                                     "returnType": null,
                                     "compoundStatementOrSemicolon": {
                                         "CompoundStatementNode": {

--- a/tests/cases/parser/anonymousFunctionCreationExpression7.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression7.php.tree
@@ -92,6 +92,7 @@
                                         }
                                     },
                                     "colonToken": null,
+                                    "questionToken": null,
                                     "returnType": null,
                                     "compoundStatementOrSemicolon": {
                                         "CompoundStatementNode": {

--- a/tests/cases/parser/classMethods1.php.tree
+++ b/tests/cases/parser/classMethods1.php.tree
@@ -62,6 +62,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/classMethods3.php.tree
+++ b/tests/cases/parser/classMethods3.php.tree
@@ -57,6 +57,7 @@
                                                 "children": [
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -74,6 +75,7 @@
                                                     },
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -93,6 +95,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/classMethods4.php.tree
+++ b/tests/cases/parser/classMethods4.php.tree
@@ -57,6 +57,7 @@
                                                 "children": [
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -74,6 +75,7 @@
                                                     },
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -96,6 +98,7 @@
                                             "kind": "ColonToken",
                                             "textLength": 1
                                         },
+                                        "questionToken": null,
                                         "returnType": {
                                             "kind": "IntReservedWord",
                                             "textLength": 3

--- a/tests/cases/parser/classMethods5.php.tree
+++ b/tests/cases/parser/classMethods5.php.tree
@@ -58,6 +58,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {
@@ -102,6 +103,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/constructorDeclaration1.php.tree
+++ b/tests/cases/parser/constructorDeclaration1.php.tree
@@ -61,6 +61,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/functions1.php.tree
+++ b/tests/cases/parser/functions1.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions10.php.tree
+++ b/tests/cases/parser/functions10.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -48,6 +49,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": {
                                             "kind": "AmpersandToken",
@@ -73,6 +75,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions11.php.tree
+++ b/tests/cases/parser/functions11.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -48,6 +49,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,
@@ -84,6 +86,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions12.php.tree
+++ b/tests/cases/parser/functions12.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -48,6 +49,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,
@@ -81,6 +83,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions13.php.tree
+++ b/tests/cases/parser/functions13.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -48,6 +49,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,
@@ -85,6 +87,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions14.php.tree
+++ b/tests/cases/parser/functions14.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -48,6 +49,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,
@@ -79,6 +81,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -98,6 +101,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions15.php.tree
+++ b/tests/cases/parser/functions15.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -48,6 +49,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,
@@ -79,6 +81,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": {
@@ -101,6 +104,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions16.php.tree
+++ b/tests/cases/parser/functions16.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -50,6 +51,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions17.php
+++ b/tests/cases/parser/functions17.php
@@ -1,0 +1,5 @@
+<?php
+
+function b(?MyClass $x, ?int $y): int {
+    return 1;
+}

--- a/tests/cases/parser/functions17.php.tree
+++ b/tests/cases/parser/functions17.php.tree
@@ -20,7 +20,7 @@
                     "byRefToken": null,
                     "name": {
                         "kind": "Name",
-                        "textLength": 6
+                        "textLength": 1
                     },
                     "openParen": {
                         "kind": "OpenParenToken",
@@ -31,8 +31,22 @@
                             "children": [
                                 {
                                     "Parameter": {
-                                        "questionToken": null,
-                                        "typeDeclaration": null,
+                                        "questionToken": {
+                                            "kind": "QuestionToken",
+                                            "textLength": 1
+                                        },
+                                        "typeDeclaration": {
+                                            "QualifiedName": {
+                                                "globalSpecifier": null,
+                                                "relativeSpecifier": null,
+                                                "nameParts": [
+                                                    {
+                                                        "kind": "Name",
+                                                        "textLength": 7
+                                                    }
+                                                ]
+                                            }
+                                        },
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
                                         "variableName": {
@@ -49,13 +63,16 @@
                                 },
                                 {
                                     "Parameter": {
-                                        "questionToken": null,
-                                        "typeDeclaration": null,
-                                        "byRefToken": null,
-                                        "dotDotDotToken": {
-                                            "kind": "DotDotDotToken",
+                                        "questionToken": {
+                                            "kind": "QuestionToken",
+                                            "textLength": 1
+                                        },
+                                        "typeDeclaration": {
+                                            "kind": "IntReservedWord",
                                             "textLength": 3
                                         },
+                                        "byRefToken": null,
+                                        "dotDotDotToken": null,
                                         "variableName": {
                                             "kind": "VariableName",
                                             "textLength": 2
@@ -71,16 +88,43 @@
                         "kind": "CloseParenToken",
                         "textLength": 1
                     },
-                    "colonToken": null,
+                    "colonToken": {
+                        "kind": "ColonToken",
+                        "textLength": 1
+                    },
                     "questionToken": null,
-                    "returnType": null,
+                    "returnType": {
+                        "kind": "IntReservedWord",
+                        "textLength": 3
+                    },
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {
                             "openBrace": {
                                 "kind": "OpenBraceToken",
                                 "textLength": 1
                             },
-                            "statements": [],
+                            "statements": [
+                                {
+                                    "ReturnStatement": {
+                                        "returnKeyword": {
+                                            "kind": "ReturnKeyword",
+                                            "textLength": 6
+                                        },
+                                        "expression": {
+                                            "NumericLiteral": {
+                                                "children": {
+                                                    "kind": "IntegerLiteralToken",
+                                                    "textLength": 1
+                                                }
+                                            }
+                                        },
+                                        "semicolon": {
+                                            "kind": "SemicolonToken",
+                                            "textLength": 1
+                                        }
+                                    }
+                                }
+                            ],
                             "closeBrace": {
                                 "kind": "CloseBraceToken",
                                 "textLength": 1

--- a/tests/cases/parser/functions18.php
+++ b/tests/cases/parser/functions18.php
@@ -1,0 +1,5 @@
+<?php
+
+function b(MyClass $x, int $y): ?int {
+    return null;
+}

--- a/tests/cases/parser/functions18.php.tree
+++ b/tests/cases/parser/functions18.php.tree
@@ -20,7 +20,7 @@
                     "byRefToken": null,
                     "name": {
                         "kind": "Name",
-                        "textLength": 6
+                        "textLength": 1
                     },
                     "openParen": {
                         "kind": "OpenParenToken",
@@ -32,7 +32,18 @@
                                 {
                                     "Parameter": {
                                         "questionToken": null,
-                                        "typeDeclaration": null,
+                                        "typeDeclaration": {
+                                            "QualifiedName": {
+                                                "globalSpecifier": null,
+                                                "relativeSpecifier": null,
+                                                "nameParts": [
+                                                    {
+                                                        "kind": "Name",
+                                                        "textLength": 7
+                                                    }
+                                                ]
+                                            }
+                                        },
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
                                         "variableName": {
@@ -50,12 +61,12 @@
                                 {
                                     "Parameter": {
                                         "questionToken": null,
-                                        "typeDeclaration": null,
-                                        "byRefToken": null,
-                                        "dotDotDotToken": {
-                                            "kind": "DotDotDotToken",
+                                        "typeDeclaration": {
+                                            "kind": "IntReservedWord",
                                             "textLength": 3
                                         },
+                                        "byRefToken": null,
+                                        "dotDotDotToken": null,
                                         "variableName": {
                                             "kind": "VariableName",
                                             "textLength": 2
@@ -71,16 +82,46 @@
                         "kind": "CloseParenToken",
                         "textLength": 1
                     },
-                    "colonToken": null,
-                    "questionToken": null,
-                    "returnType": null,
+                    "colonToken": {
+                        "kind": "ColonToken",
+                        "textLength": 1
+                    },
+                    "questionToken": {
+                        "kind": "QuestionToken",
+                        "textLength": 1
+                    },
+                    "returnType": {
+                        "kind": "IntReservedWord",
+                        "textLength": 3
+                    },
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {
                             "openBrace": {
                                 "kind": "OpenBraceToken",
                                 "textLength": 1
                             },
-                            "statements": [],
+                            "statements": [
+                                {
+                                    "ReturnStatement": {
+                                        "returnKeyword": {
+                                            "kind": "ReturnKeyword",
+                                            "textLength": 6
+                                        },
+                                        "expression": {
+                                            "ReservedWord": {
+                                                "children": {
+                                                    "kind": "NullReservedWord",
+                                                    "textLength": 4
+                                                }
+                                            }
+                                        },
+                                        "semicolon": {
+                                            "kind": "SemicolonToken",
+                                            "textLength": 1
+                                        }
+                                    }
+                                }
+                            ],
                             "closeBrace": {
                                 "kind": "CloseBraceToken",
                                 "textLength": 1

--- a/tests/cases/parser/functions2.php.tree
+++ b/tests/cases/parser/functions2.php.tree
@@ -35,6 +35,7 @@
                         "kind": "ColonToken",
                         "textLength": 1
                     },
+                    "questionToken": null,
                     "returnType": {
                         "kind": "IntReservedWord",
                         "textLength": 3

--- a/tests/cases/parser/functions3.php.tree
+++ b/tests/cases/parser/functions3.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,
@@ -59,6 +60,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": {
                                             "kind": "IntReservedWord",
                                             "textLength": 3
@@ -84,6 +86,7 @@
                         "kind": "ColonToken",
                         "textLength": 1
                     },
+                    "questionToken": null,
                     "returnType": {
                         "kind": "IntReservedWord",
                         "textLength": 3

--- a/tests/cases/parser/functions4.php.tree
+++ b/tests/cases/parser/functions4.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions5.php.tree
+++ b/tests/cases/parser/functions5.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions6.php.tree
+++ b/tests/cases/parser/functions6.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -59,6 +60,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -78,6 +80,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions7.php.tree
+++ b/tests/cases/parser/functions7.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -55,6 +56,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -74,6 +76,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/functions8.php.tree
+++ b/tests/cases/parser/functions8.php.tree
@@ -31,6 +31,7 @@
                             "children": [
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -48,6 +49,7 @@
                                 },
                                 {
                                     "Parameter": {
+                                        "questionToken": null,
                                         "typeDeclaration": null,
                                         "byRefToken": null,
                                         "dotDotDotToken": null,
@@ -70,6 +72,7 @@
                         "kind": "ColonToken",
                         "textLength": 1
                     },
+                    "questionToken": null,
                     "returnType": {
                         "error": "MissingToken",
                         "kind": "ReturnType",

--- a/tests/cases/parser/interfaceDeclaration10.php.tree
+++ b/tests/cases/parser/interfaceDeclaration10.php.tree
@@ -55,6 +55,7 @@
                                                 "children": [
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -72,6 +73,7 @@
                                                     },
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -104,6 +106,7 @@
                                             "kind": "ColonToken",
                                             "textLength": 1
                                         },
+                                        "questionToken": null,
                                         "returnType": {
                                             "kind": "BoolReservedWord",
                                             "textLength": 4

--- a/tests/cases/parser/interfaceDeclaration11.php.tree
+++ b/tests/cases/parser/interfaceDeclaration11.php.tree
@@ -56,6 +56,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "kind": "SemicolonToken",
@@ -90,6 +91,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "kind": "SemicolonToken",

--- a/tests/cases/parser/interfaceDeclaration12.php.tree
+++ b/tests/cases/parser/interfaceDeclaration12.php.tree
@@ -56,6 +56,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {
@@ -101,6 +102,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/interfaceDeclaration13.php.tree
+++ b/tests/cases/parser/interfaceDeclaration13.php.tree
@@ -60,6 +60,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "kind": "SemicolonToken",

--- a/tests/cases/parser/interfaceDeclaration14.php.tree
+++ b/tests/cases/parser/interfaceDeclaration14.php.tree
@@ -56,6 +56,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/interfaceDeclaration7.php.tree
+++ b/tests/cases/parser/interfaceDeclaration7.php.tree
@@ -56,6 +56,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "kind": "SemicolonToken",

--- a/tests/cases/parser/interfaceDeclaration8.php.tree
+++ b/tests/cases/parser/interfaceDeclaration8.php.tree
@@ -55,6 +55,7 @@
                                                 "children": [
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -72,6 +73,7 @@
                                                     },
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -91,6 +93,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "kind": "SemicolonToken",

--- a/tests/cases/parser/interfaceDeclaration9.php.tree
+++ b/tests/cases/parser/interfaceDeclaration9.php.tree
@@ -55,6 +55,7 @@
                                                 "children": [
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -72,6 +73,7 @@
                                                     },
                                                     {
                                                         "Parameter": {
+                                                            "questionToken": null,
                                                             "typeDeclaration": null,
                                                             "byRefToken": null,
                                                             "dotDotDotToken": null,
@@ -101,6 +103,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "kind": "SemicolonToken",

--- a/tests/cases/parser/namespaces2.php.tree
+++ b/tests/cases/parser/namespaces2.php.tree
@@ -56,6 +56,7 @@
                                             "kind": "ColonToken",
                                             "textLength": 1
                                         },
+                                        "questionToken": null,
                                         "returnType": {
                                             "QualifiedName": {
                                                 "globalSpecifier": {

--- a/tests/cases/parser/namespaces3.php.tree
+++ b/tests/cases/parser/namespaces3.php.tree
@@ -56,6 +56,7 @@
                                             "kind": "ColonToken",
                                             "textLength": 1
                                         },
+                                        "questionToken": null,
                                         "returnType": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,

--- a/tests/cases/parser/namespaces4.php.tree
+++ b/tests/cases/parser/namespaces4.php.tree
@@ -56,6 +56,7 @@
                                             "kind": "ColonToken",
                                             "textLength": 1
                                         },
+                                        "questionToken": null,
                                         "returnType": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,

--- a/tests/cases/parser/namespaces5.php.tree
+++ b/tests/cases/parser/namespaces5.php.tree
@@ -56,6 +56,7 @@
                                             "kind": "ColonToken",
                                             "textLength": 1
                                         },
+                                        "questionToken": null,
                                         "returnType": {
                                             "QualifiedName": {
                                                 "globalSpecifier": null,

--- a/tests/cases/parser/objectCreationExpression7.php.tree
+++ b/tests/cases/parser/objectCreationExpression7.php.tree
@@ -68,6 +68,7 @@
                                                     "textLength": 1
                                                 },
                                                 "colonToken": null,
+                                                "questionToken": null,
                                                 "returnType": null,
                                                 "compoundStatementOrSemicolon": {
                                                     "CompoundStatementNode": {

--- a/tests/cases/parser/objectCreationExpression8.php.tree
+++ b/tests/cases/parser/objectCreationExpression8.php.tree
@@ -105,6 +105,7 @@
                                                     "textLength": 1
                                                 },
                                                 "colonToken": null,
+                                                "questionToken": null,
                                                 "returnType": null,
                                                 "compoundStatementOrSemicolon": {
                                                     "CompoundStatementNode": {

--- a/tests/cases/parser/programStructure6.php.tree
+++ b/tests/cases/parser/programStructure6.php.tree
@@ -86,6 +86,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/switchStatement6.php.tree
+++ b/tests/cases/parser/switchStatement6.php.tree
@@ -73,6 +73,7 @@
                                                 "textLength": 1
                                             },
                                             "colonToken": null,
+                                            "questionToken": null,
                                             "returnType": null,
                                             "compoundStatementOrSemicolon": {
                                                 "CompoundStatementNode": {

--- a/tests/cases/parser/whileStatement3.php.tree
+++ b/tests/cases/parser/whileStatement3.php.tree
@@ -58,6 +58,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {
@@ -176,6 +177,7 @@
                                             "textLength": 1
                                         },
                                         "colonToken": null,
+                                        "questionToken": null,
                                         "returnType": null,
                                         "compoundStatementOrSemicolon": {
                                             "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression10.php.tree
+++ b/tests/cases/parser/yieldExpression10.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression10_from.php.tree
+++ b/tests/cases/parser/yieldExpression10_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression11.php.tree
+++ b/tests/cases/parser/yieldExpression11.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression11_from.php.tree
+++ b/tests/cases/parser/yieldExpression11_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression12.php.tree
+++ b/tests/cases/parser/yieldExpression12.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression12_from.php.tree
+++ b/tests/cases/parser/yieldExpression12_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression13.php.tree
+++ b/tests/cases/parser/yieldExpression13.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression13_from.php.tree
+++ b/tests/cases/parser/yieldExpression13_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression14.php.tree
+++ b/tests/cases/parser/yieldExpression14.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression14_from.php.tree
+++ b/tests/cases/parser/yieldExpression14_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression15.php.tree
+++ b/tests/cases/parser/yieldExpression15.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression15_from.php.tree
+++ b/tests/cases/parser/yieldExpression15_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression16.php.tree
+++ b/tests/cases/parser/yieldExpression16.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression16_from.php.tree
+++ b/tests/cases/parser/yieldExpression16_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression17.php.tree
+++ b/tests/cases/parser/yieldExpression17.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression17_from.php.tree
+++ b/tests/cases/parser/yieldExpression17_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression2.php.tree
+++ b/tests/cases/parser/yieldExpression2.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression2_from.php.tree
+++ b/tests/cases/parser/yieldExpression2_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression3.php.tree
+++ b/tests/cases/parser/yieldExpression3.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression3_from.php.tree
+++ b/tests/cases/parser/yieldExpression3_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression4.php.tree
+++ b/tests/cases/parser/yieldExpression4.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression4_from.php.tree
+++ b/tests/cases/parser/yieldExpression4_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression5.php.tree
+++ b/tests/cases/parser/yieldExpression5.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression5_from.php.tree
+++ b/tests/cases/parser/yieldExpression5_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression6.php.tree
+++ b/tests/cases/parser/yieldExpression6.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression6_from.php.tree
+++ b/tests/cases/parser/yieldExpression6_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression7.php.tree
+++ b/tests/cases/parser/yieldExpression7.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression7_from.php.tree
+++ b/tests/cases/parser/yieldExpression7_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression8.php.tree
+++ b/tests/cases/parser/yieldExpression8.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression8_from.php.tree
+++ b/tests/cases/parser/yieldExpression8_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression9.php.tree
+++ b/tests/cases/parser/yieldExpression9.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {

--- a/tests/cases/parser/yieldExpression9_from.php.tree
+++ b/tests/cases/parser/yieldExpression9_from.php.tree
@@ -32,6 +32,7 @@
                         "textLength": 1
                     },
                     "colonToken": null,
+                    "questionToken": null,
                     "returnType": null,
                     "compoundStatementOrSemicolon": {
                         "CompoundStatementNode": {


### PR DESCRIPTION
Add a `questionToken` prop to parameter and function return type declarations. Could be picked up by the language server to show `<type>|null`.