### PR TITLE
Fix use of count() on a string value

### DIFF
--- a/src/PhpTokenizer.php
+++ b/src/PhpTokenizer.php
@@ -75,7 +75,7 @@ class PhpTokenizer implements TokenStreamProviderInterface {
             $pos += $strlen;
 
             if ($parseContext !== null && !$passedPrefix) {
-                $passedPrefix = \count($prefix) < $pos;
+                $passedPrefix = \strlen($prefix) < $pos;
                 if ($passedPrefix) {
                     $fullStart = $start = $pos = $initialPos;
                 }


### PR DESCRIPTION
This is no longer allowed in PHP 7.2, and is typically unwanted.
See https://wiki.php.net/rfc/counting_non_countables