### PR TITLE
Allow mulitiple edits at the same offset.

### DIFF
--- a/src/TextEdit.php
+++ b/src/TextEdit.php
@@ -36,10 +36,14 @@ class TextEdit {
         $prevEditStart = PHP_INT_MAX;
         for ($i = \count($edits) - 1; $i >= 0; $i--) {
             $edit = $edits[$i];
-            \assert(
-                $prevEditStart > $edit->start && $prevEditStart > $edit->start + $edit->length,
-                "Supplied TextEdit[] must not overlap, and be in increasing start position order."
-            );
+
+            if ($prevEditStart < $edit->start || $prevEditStart < $edit->start + $edit->length) {
+                throw new \OutOfBoundsException(sprintf(
+                    'Supplied TextEdit[] "%s" must not overlap and be in increasing start position order.',
+                    $edit->content
+                ));
+            }
+
             if ($edit->start < 0 || $edit->length < 0 || $edit->start + $edit->length > \strlen($text)) {
                 throw new \OutOfBoundsException("Applied TextEdit range out of bounds.");
             }

--- a/tests/api/TextEditTest.php
+++ b/tests/api/TextEditTest.php
@@ -75,6 +75,27 @@ PHP;
         $this->assertEquals($expected, TextEdit::applyEdits($edits, $content));
     }
 
+    public function testApplyMultipleEditsAtSameOffset() {
+        $content = self::INPUT_TEXT;
+
+        $expected = <<< 'PHP'
+helloawesome<?php
+
+function a () { }
+
+function b () { }
+PHP
+        ;
+        $edits = [
+            new TextEdit(0, 0, "hello"),
+            new TextEdit(0, 0, "awesome"),
+            new TextEdit(0, 0, "")
+        ];
+
+        $this->assertEquals($expected, TextEdit::applyEdits($edits, $content));
+    }
+
+
     public function testApplyingEmptyTextEditArray() {
         $content = self::INPUT_TEXT;
 
@@ -88,7 +109,7 @@ PHP;
             new TextEdit(0, 10, 10),
             new TextEdit(0, 4 ,3)
         ];
-        $this->expectException(AssertionError::class);
+        $this->expectException(OutOfBoundsException::class);
         TextEdit::applyEdits($edits, $content);
     }
 
@@ -98,7 +119,7 @@ PHP;
             new TextEdit(0, 4, 10),
             new TextEdit(0, 10, 10)
         ];
-        $this->expectException(AssertionError::class);
+        $this->expectException(OutOfBoundsException::class);
         TextEdit::applyEdits($edits, $content);
     }
 


### PR DESCRIPTION
Currently an Assertion error is thrown when text edits are made in the wrong order AND when multiple edits are made in the same place. Which I believe is a mistake as this works as expected until I run it in an environment with assertions turned on:

```php
$source = '<?php';
$textEdits[] = new TextEdit(0, 0, 'Hello');
$textEdits[] = new TextEdit(0, 0, 'World');
echo TextEdit::applyEdits($textEdits, $source);
```

Expected:

```
HelloWorld<?php
```

Actual: Assertion error is thrown.

If assertions are disabled (`zend.assertions = -1`) this works as expected.

In addtion I changed the assertion to an `OutOfBounds` exception due to the inconsitency of the behavior of `assert`.