### PR TITLE
Fix error

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ var_dump($astNode);
 // Gets and prints errors from AST Node. The parser handles errors gracefully,
 // so it can be used in IDE usage scenarios (where code is often incomplete).
 $errors = DiagnosticsProvider::getDiagnostics($astNode);
-var_dump(iterator_to_array($errors));
+var_dump($errors);
 
 // Traverse all Node descendants of $astNode
 foreach ($astNode->getDescendantNodes() as $descendant) {


### PR DESCRIPTION
Fix error PHP Fatal error:  Uncaught TypeError: Argument 1 passed to iterator_to_array() must implement interface Traversable, array given

https://github.com/Microsoft/tolerant-php-parser/issues/159