### PR TITLE
Normalize spaces in union types in comments ("A | B" -> "A|B")

### DIFF
--- a/src/DiagnosticsProvider.php
+++ b/src/DiagnosticsProvider.php
@@ -9,14 +9,14 @@ namespace Microsoft\PhpParser;
 use Microsoft\PhpParser\Node;
 
 class DiagnosticsProvider {
-    /**
-     * Traverses AST to generate diagnostics.
-     * @param \Microsoft\PhpParser\Node $node
-     * @return \Generator | Diagnostic[]
-     */
 
     private static $tokenKindToText;
 
+    /**
+     * Returns the diagnostic for $node, or null.
+     * @param \Microsoft\PhpParser\Node $node
+     * @return Diagnostic|null
+     */
     public static function checkDiagnostics($node) {
         if (!isset(self::$tokenKindToText)) {
             self::$tokenKindToText = \array_flip(\array_merge(
@@ -88,6 +88,11 @@ class DiagnosticsProvider {
         return null;
     }
 
+    /**
+     * Traverses AST to generate diagnostics.
+     * @param \Microsoft\PhpParser\Node $n
+     * @return Diagnostic[]
+     */
     public static function getDiagnostics(Node $n) : array {
         $diagnostics = [];
 

--- a/src/Node.php
+++ b/src/Node.php
@@ -16,7 +16,7 @@ abstract class Node implements \JsonSerializable {
     /** @var array[] Map from node class to array of child keys */
     private static $childNames = [];
 
-    /** @var Node | null */
+    /** @var Node|null */
     public $parent;
 
     public function getNodeKindName() : string {
@@ -187,7 +187,7 @@ abstract class Node implements \JsonSerializable {
     /**
      * Gets generator containing all descendant Tokens.
      * @param callable|null $shouldDescendIntoChildrenFn
-     * @return \Generator | Token[]
+     * @return \Generator|Token[]
      */
     public function getDescendantTokens(callable $shouldDescendIntoChildrenFn = null) {
         foreach ($this->getChildNodesAndTokens() as $child) {
@@ -205,7 +205,7 @@ abstract class Node implements \JsonSerializable {
      * Gets generator containing all child Nodes and Tokens (direct descendants).
      * Does not return null elements.
      *
-     * @return \Generator | Token[] | Node[]
+     * @return \Generator|Token[]|Node[]
      */
     public function getChildNodesAndTokens() : \Generator {
         foreach ($this::CHILD_NAMES as $name) {
@@ -227,7 +227,7 @@ abstract class Node implements \JsonSerializable {
 
     /**
      * Gets generator containing all child Nodes (direct descendants)
-     * @return \Generator | Node[]
+     * @return \Generator|Node[]
      */
     public function getChildNodes() : \Generator {
         foreach ($this::CHILD_NAMES as $name) {
@@ -425,7 +425,7 @@ abstract class Node implements \JsonSerializable {
      * Returns last doc comment in leading comment / whitespace trivia,
      * and returns null if there is no preceding doc comment.
      *
-     * @return string | null
+     * @return string|null
      */
     public function getDocCommentText() {
         $leadingTriviaText = $this->getLeadingCommentAndWhitespaceText();
@@ -446,7 +446,7 @@ abstract class Node implements \JsonSerializable {
     }
 
     /**
-     * @return array | ResolvedName[][]
+     * @return array|ResolvedName[][]
      * @throws \Exception
      */
     public function getImportTablesForCurrentScope() {
@@ -547,7 +547,7 @@ abstract class Node implements \JsonSerializable {
     /**
      * Gets corresponding NamespaceDefinition for Node. Returns null if in global namespace.
      *
-     * @return NamespaceDefinition | null
+     * @return NamespaceDefinition|null
      */
     public function getNamespaceDefinition() {
         $namespaceDefinition = $this instanceof NamespaceDefinition

--- a/src/Node/ArrayElement.php
+++ b/src/Node/ArrayElement.php
@@ -11,13 +11,13 @@ use Microsoft\PhpParser\Token;
 
 class ArrayElement extends Node {
 
-    /** @var Expression | null */
+    /** @var Expression|null */
     public $elementKey;
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $arrowToken;
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $byRef;
 
     /** @var Expression */

--- a/src/Node/ClassInterfaceClause.php
+++ b/src/Node/ClassInterfaceClause.php
@@ -13,7 +13,7 @@ class ClassInterfaceClause extends Node {
     /** @var Token */
     public $implementsKeyword;
 
-    /** @var DelimitedList\QualifiedNameList | null */
+    /** @var DelimitedList\QualifiedNameList|null */
     public $interfaceNameList;
 
     const CHILD_NAMES = [

--- a/src/Node/ElseClauseNode.php
+++ b/src/Node/ElseClauseNode.php
@@ -14,7 +14,7 @@ class ElseClauseNode extends Node {
     public $elseKeyword;
     /** @var Token */
     public $colon;
-    /** @var StatementNode | StatementNode[] */
+    /** @var StatementNode|StatementNode[] */
     public $statements;
 
     const CHILD_NAMES = [

--- a/src/Node/ElseIfClauseNode.php
+++ b/src/Node/ElseIfClauseNode.php
@@ -18,9 +18,9 @@ class ElseIfClauseNode extends Node {
     public $expression;
     /** @var Token */
     public $closeParen;
-    /** @var Token | null */
+    /** @var Token|null */
     public $colon;
-    /** @var StatementNode | StatementNode[] */
+    /** @var StatementNode|StatementNode[] */
     public $statements;
 
     const CHILD_NAMES = [

--- a/src/Node/Expression/AnonymousFunctionCreationExpression.php
+++ b/src/Node/Expression/AnonymousFunctionCreationExpression.php
@@ -15,7 +15,7 @@ use Microsoft\PhpParser\Node\FunctionUseClause;
 use Microsoft\PhpParser\Token;
 
 class AnonymousFunctionCreationExpression extends Expression implements FunctionLike {
-    /** @var Token | null */
+    /** @var Token|null */
     public $staticModifier;
 
     use FunctionHeader, FunctionUseClause, FunctionReturnType, FunctionBody;

--- a/src/Node/Expression/ArgumentExpression.php
+++ b/src/Node/Expression/ArgumentExpression.php
@@ -10,10 +10,10 @@ use Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Token;
 
 class ArgumentExpression extends Expression {
-    /** @var Token | null */
+    /** @var Token|null */
     public $byRefToken; // TODO removed in newer versions of PHP. Also only accept variable, not expression if byRef
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $dotDotDotToken;
 
     /** @var Expression */

--- a/src/Node/Expression/ArrayCreationExpression.php
+++ b/src/Node/Expression/ArrayCreationExpression.php
@@ -12,7 +12,7 @@ use Microsoft\PhpParser\Token;
 
 class ArrayCreationExpression extends Expression {
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $arrayKeyword;
 
     /** @var Token */

--- a/src/Node/Expression/CallExpression.php
+++ b/src/Node/Expression/CallExpression.php
@@ -17,7 +17,7 @@ class CallExpression extends Expression {
     /** @var Token */
     public $openParen;
 
-    /** @var DelimitedList\ArgumentExpressionList | null */
+    /** @var DelimitedList\ArgumentExpressionList|null */
     public $argumentExpressionList;
 
     /** @var Token */

--- a/src/Node/Expression/ExitIntrinsicExpression.php
+++ b/src/Node/Expression/ExitIntrinsicExpression.php
@@ -14,13 +14,13 @@ class ExitIntrinsicExpression extends Expression {
     /** @var Token */
     public $exitOrDieKeyword;
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $openParen;
 
-    /** @var Expression | null */
+    /** @var Expression|null */
     public $expression;
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $closeParen;
 
     const CHILD_NAMES = [

--- a/src/Node/Expression/ObjectCreationExpression.php
+++ b/src/Node/Expression/ObjectCreationExpression.php
@@ -19,25 +19,25 @@ class ObjectCreationExpression extends Expression {
     /** @var Token */
     public $newKeword;
 
-    /** @var QualifiedName | Variable | Token */
+    /** @var QualifiedName|Variable|Token */
     public $classTypeDesignator;
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $openParen;
 
-    /** @var DelimitedList\ArgumentExpressionList | null  */
+    /** @var DelimitedList\ArgumentExpressionList|null  */
     public $argumentExpressionList;
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $closeParen;
 
-    /** @var ClassBaseClause | null */
+    /** @var ClassBaseClause|null */
     public $classBaseClause;
 
-    /** @var ClassInterfaceClause | null */
+    /** @var ClassInterfaceClause|null */
     public $classInterfaceClause;
 
-    /** @var ClassMembersNode | null */
+    /** @var ClassMembersNode|null */
     public $classMembers;
 
     const CHILD_NAMES = [

--- a/src/Node/Expression/ScopedPropertyAccessExpression.php
+++ b/src/Node/Expression/ScopedPropertyAccessExpression.php
@@ -12,13 +12,13 @@ use Microsoft\PhpParser\Token;
 
 class ScopedPropertyAccessExpression extends Expression {
 
-    /** @var Expression | QualifiedName | Token */
+    /** @var Expression|QualifiedName|Token */
     public $scopeResolutionQualifier;
 
     /** @var Token */
     public $doubleColon;
 
-    /** @var Token | Variable */
+    /** @var Token|Variable */
     public $memberName;
 
     const CHILD_NAMES = [

--- a/src/Node/Expression/UnaryExpression.php
+++ b/src/Node/Expression/UnaryExpression.php
@@ -9,7 +9,7 @@ namespace Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Node\Expression;
 
 class UnaryExpression extends Expression {
-    /** @var UnaryExpression | Variable */
+    /** @var UnaryExpression|Variable */
     public $operand;
 
     const CHILD_NAMES = [

--- a/src/Node/Expression/Variable.php
+++ b/src/Node/Expression/Variable.php
@@ -13,7 +13,7 @@ class Variable extends Expression {
     /** @var Token */
     public $dollar;
 
-    /** @var Token | Variable | BracedExpression */
+    /** @var Token|Variable|BracedExpression */
     public $name;
 
     const CHILD_NAMES = [

--- a/src/Node/ForeachValue.php
+++ b/src/Node/ForeachValue.php
@@ -10,7 +10,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;
 
 class ForeachValue extends Node {
-    /** @var Token | null */
+    /** @var Token|null */
     public $ampersand;
     /** @var Expression */
     public $expression;

--- a/src/Node/FunctionBody.php
+++ b/src/Node/FunctionBody.php
@@ -10,6 +10,6 @@ use Microsoft\PhpParser\Node\Statement\CompoundStatementNode;
 use Microsoft\PhpParser\Token;
 
 trait FunctionBody {
-    /** @var CompoundStatementNode | Token */
+    /** @var CompoundStatementNode|Token */
     public $compoundStatementOrSemicolon;
 }

--- a/src/Node/FunctionHeader.php
+++ b/src/Node/FunctionHeader.php
@@ -13,7 +13,7 @@ trait FunctionHeader {
     public $functionKeyword;
     /** @var Token */
     public $byRefToken;
-    /** @var null | Token */
+    /** @var null|Token */
     public $name;
     /** @var Token */
     public $openParen;

--- a/src/Node/FunctionReturnType.php
+++ b/src/Node/FunctionReturnType.php
@@ -13,6 +13,6 @@ trait FunctionReturnType {
     public $colonToken;
     /** @var Token|null */
     public $questionToken;
-    /** @var Token | QualifiedName */
+    /** @var Token|QualifiedName */
     public $returnType;
 }

--- a/src/Node/FunctionUseClause.php
+++ b/src/Node/FunctionUseClause.php
@@ -7,6 +7,6 @@
 namespace Microsoft\PhpParser\Node;
 
 trait FunctionUseClause {
-    /** @var AnonymousFunctionUseClause | null */
+    /** @var AnonymousFunctionUseClause|null */
     public $anonymousFunctionUseClause;
 }

--- a/src/Node/NamespaceUseClause.php
+++ b/src/Node/NamespaceUseClause.php
@@ -15,11 +15,11 @@ class NamespaceUseClause extends Node {
     public $namespaceName;
     /** @var NamespaceAliasingClause */
     public $namespaceAliasingClause;
-    /** @var Token | null */
+    /** @var Token|null */
     public $openBrace;
-    /** @var DelimitedList\NamespaceUseGroupClauseList | null */
+    /** @var DelimitedList\NamespaceUseGroupClauseList|null */
     public $groupClauses;
-    /** @var  Token | null */
+    /** @var Token|null */
     public $closeBrace;
 
     const CHILD_NAMES = [

--- a/src/Node/Parameter.php
+++ b/src/Node/Parameter.php
@@ -12,17 +12,17 @@ use Microsoft\PhpParser\Token;
 class Parameter extends Node {
     /** @var Token|null */
     public $questionToken;
-    /** @var QualifiedName | Token | null */
+    /** @var QualifiedName|Token|null */
     public $typeDeclaration;
-    /** @var Token | null */
+    /** @var Token|null */
     public $byRefToken;
-    /** @var Token | null */
+    /** @var Token|null */
     public $dotDotDotToken;
     /** @var Token */
     public $variableName;
-    /** @var Token | null */
+    /** @var Token|null */
     public $equalsToken;
-    /** @var null | Expression */
+    /** @var null|Expression */
     public $default;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/BreakOrContinueStatement.php
+++ b/src/Node/Statement/BreakOrContinueStatement.php
@@ -12,7 +12,7 @@ use Microsoft\PhpParser\Token;
 class BreakOrContinueStatement extends StatementNode {
     /** @var Token */
     public $breakOrContinueKeyword;
-    /** @var Token | null */
+    /** @var Token|null */
     public $breakoutLevel;
     /** @var Token */
     public $semicolon;

--- a/src/Node/Statement/CompoundStatementNode.php
+++ b/src/Node/Statement/CompoundStatementNode.php
@@ -14,7 +14,7 @@ class CompoundStatementNode extends StatementNode {
     /** @var Token */
     public $openBrace;
 
-    /** @var array | Node[] */
+    /** @var array|Node[] */
     public $statements;
 
     /** @var Token */

--- a/src/Node/Statement/DeclareStatement.php
+++ b/src/Node/Statement/DeclareStatement.php
@@ -19,13 +19,13 @@ class DeclareStatement extends StatementNode {
     public $declareDirective;
     /** @var Token */
     public $closeParen;
-    /** @var Token | null */
+    /** @var Token|null */
     public $colon;
-    /** @var StatementNode | StatementNode[] */
+    /** @var StatementNode|StatementNode[] */
     public $statements;
-    /** @var Token | null */
+    /** @var Token|null */
     public $enddeclareKeyword;
-    /** @var Token | null */
+    /** @var Token|null */
     public $semicolon;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/DoStatement.php
+++ b/src/Node/Statement/DoStatement.php
@@ -23,7 +23,7 @@ class DoStatement extends StatementNode {
     public $expression;
     /** @var Token */
     public $closeParen;
-    /** @var Token | null */
+    /** @var Token|null */
     public $semicolon;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/ForStatement.php
+++ b/src/Node/Statement/ForStatement.php
@@ -15,25 +15,25 @@ class ForStatement extends StatementNode {
     public $for;
     /** @var Token */
     public $openParen;
-    /** @var Expression | null */
+    /** @var Expression|null */
     public $forInitializer;
     /** @var Token */
     public $exprGroupSemicolon1;
-    /** @var Expression | null */
+    /** @var Expression|null */
     public $forControl;
     /** @var Token */
     public $exprGroupSemicolon2;
-    /** @var Expression | null */
+    /** @var Expression|null */
     public $forEndOfLoop;
     /** @var Token */
     public $closeParen;
-    /** @var Token | null */
+    /** @var Token|null */
     public $colon;
-    /** @var StatementNode | StatementNode[] */
+    /** @var StatementNode|StatementNode[] */
     public $statements;
-    /** @var Token | null */
+    /** @var Token|null */
     public $endFor;
-    /** @var Token | null */
+    /** @var Token|null */
     public $endForSemicolon;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/ForeachStatement.php
+++ b/src/Node/Statement/ForeachStatement.php
@@ -21,19 +21,19 @@ class ForeachStatement extends StatementNode {
     public $forEachCollectionName;
     /** @var Token */
     public $asKeyword;
-    /** @var ForeachKey | null */
+    /** @var ForeachKey|null */
     public $foreachKey;
     /** @var ForeachValue */
     public $foreachValue;
     /** @var Token */
     public $closeParen;
-    /** @var Token | null */
+    /** @var Token|null */
     public $colon;
-    /** @var StatementNode | StatementNode[] */
+    /** @var StatementNode|StatementNode[] */
     public $statements;
-    /** @var Token | null */
+    /** @var Token|null */
     public $endForeach;
-    /** @var Token | null */
+    /** @var Token|null */
     public $endForeachSemicolon;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/IfStatementNode.php
+++ b/src/Node/Statement/IfStatementNode.php
@@ -21,17 +21,17 @@ class IfStatementNode extends StatementNode {
     public $expression;
     /** @var Token */
     public $closeParen;
-    /** @var Token | null */
+    /** @var Token|null */
     public $colon;
-    /** @var StatementNode | StatementNode[] */
+    /** @var StatementNode|StatementNode[] */
     public $statements;
     /** @var ElseIfClauseNode[] */
     public $elseIfClauses;
-    /** @var ElseClauseNode | null */
+    /** @var ElseClauseNode|null */
     public $elseClause;
-    /** @var Token | null */
+    /** @var Token|null */
     public $endifKeyword;
-    /** @var Token | null */
+    /** @var Token|null */
     public $semicolon;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/InlineHtml.php
+++ b/src/Node/Statement/InlineHtml.php
@@ -10,13 +10,13 @@ use Microsoft\PhpParser\Node\StatementNode;
 use Microsoft\PhpParser\Token;
 
 class InlineHtml extends StatementNode {
-    /** @var Token | null */
+    /** @var Token|null */
     public $scriptSectionEndTag;
 
     /** @var Token */
     public $text;
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $scriptSectionStartTag;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/InterfaceDeclaration.php
+++ b/src/Node/Statement/InterfaceDeclaration.php
@@ -23,7 +23,7 @@ class InterfaceDeclaration extends StatementNode implements NamespacedNameInterf
     /** @var Token */
     public $name;
 
-    /** @var InterfaceBaseClause | null */
+    /** @var InterfaceBaseClause|null */
     public $interfaceBaseClause;
 
     /** @var InterfaceMembers */

--- a/src/Node/Statement/NamespaceDefinition.php
+++ b/src/Node/Statement/NamespaceDefinition.php
@@ -13,9 +13,9 @@ use Microsoft\PhpParser\Token;
 class NamespaceDefinition extends StatementNode {
     /** @var Token */
     public $namespaceKeyword;
-    /** @var QualifiedName | null */
+    /** @var QualifiedName|null */
     public $name;
-    /** @var CompoundStatementNode | Token */
+    /** @var CompoundStatementNode|Token */
     public $compoundStatementOrSemicolon;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/ReturnStatement.php
+++ b/src/Node/Statement/ReturnStatement.php
@@ -13,7 +13,7 @@ use Microsoft\PhpParser\Token;
 class ReturnStatement extends StatementNode {
     /** @var Token */
     public $returnKeyword;
-    /** @var Expression | null */
+    /** @var Expression|null */
     public $expression;
     /** @var Token */
     public $semicolon;

--- a/src/Node/Statement/SwitchStatementNode.php
+++ b/src/Node/Statement/SwitchStatementNode.php
@@ -20,17 +20,17 @@ class SwitchStatementNode extends StatementNode {
     public $expression;
     /** @var Token */
     public $closeParen;
-    /** @var Token | null */
+    /** @var Token|null */
     public $colon;
-    /** @var Token | null */
+    /** @var Token|null */
     public $openBrace;
     /** @var CaseStatementNode[] */
     public $caseStatements;
-    /** @var Token | null */
+    /** @var Token|null */
     public $closeBrace;
-    /** @var Token | null */
+    /** @var Token|null */
     public $endswitch;
-    /** @var Token | null */
+    /** @var Token|null */
     public $semicolon;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/TryStatement.php
+++ b/src/Node/Statement/TryStatement.php
@@ -16,9 +16,9 @@ class TryStatement extends StatementNode {
     public $tryKeyword;
     /** @var StatementNode */
     public $compoundStatement;
-    /** @var CatchClause[] | null */
+    /** @var CatchClause[]|null */
     public $catchClauses;
-    /** @var FinallyClause | null */
+    /** @var FinallyClause|null */
     public $finallyClause;
 
     const CHILD_NAMES = [

--- a/src/Node/Statement/WhileStatement.php
+++ b/src/Node/Statement/WhileStatement.php
@@ -19,13 +19,13 @@ class WhileStatement extends StatementNode {
     public $expression;
     /** @var Token */
     public $closeParen;
-    /** @var Token | null */
+    /** @var Token|null */
     public $colon;
-    /** @var StatementNode | StatementNode[] */
+    /** @var StatementNode|StatementNode[] */
     public $statements;
-    /** @var Token | null */
+    /** @var Token|null */
     public $endWhile;
-    /** @var Token | null */
+    /** @var Token|null */
     public $semicolon;
 
     const CHILD_NAMES = [

--- a/src/Node/StaticVariableDeclaration.php
+++ b/src/Node/StaticVariableDeclaration.php
@@ -14,10 +14,10 @@ class StaticVariableDeclaration extends Node {
     /** @var Token */
     public $variableName;
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $equalsToken;
 
-    /** @var Expression | null */
+    /** @var Expression|null */
     public $assignment;
 
     const CHILD_NAMES = [

--- a/src/Node/TraitSelectOrAliasClause.php
+++ b/src/Node/TraitSelectOrAliasClause.php
@@ -10,7 +10,7 @@ use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;
 
 class TraitSelectOrAliasClause extends Node {
-    /** @var QualifiedName | Node\Expression\ScopedPropertyAccessExpression */
+    /** @var QualifiedName|Node\Expression\ScopedPropertyAccessExpression */
     public $name;
 
     /** @var Token */
@@ -19,7 +19,7 @@ class TraitSelectOrAliasClause extends Node {
     /** @var Token[] */
     public $modifiers;
 
-    /** @var QualifiedName | Node\Expression\ScopedPropertyAccessExpression */
+    /** @var QualifiedName|Node\Expression\ScopedPropertyAccessExpression */
     public $targetName;
 
     const CHILD_NAMES = [

--- a/src/Node/UseVariableName.php
+++ b/src/Node/UseVariableName.php
@@ -12,7 +12,7 @@ use Microsoft\PhpParser\Token;
 class UseVariableName extends Node {
     const CHILD_NAMES = ['byRef', 'variableName'];
 
-    /** @var Token | null */
+    /** @var Token|null */
     public $byRef;
 
     /** @var Token */

--- a/src/ResolvedName.php
+++ b/src/ResolvedName.php
@@ -10,7 +10,7 @@ class ResolvedName {
     private $parts = [];
 
     /**
-     * @param array | Token[] $tokens
+     * @param Token[] $tokens
      */
     public static function buildName(array $tokens, $content) : ResolvedName {
         $name = new ResolvedName();

--- a/src/TextEdit.php
+++ b/src/TextEdit.php
@@ -28,7 +28,7 @@ class TextEdit {
      *
      * Note that after applying edits, the original AST should be invalidated.
      *
-     * @param array | TextEdit[] $edits
+     * @param TextEdit[] $edits
      * @param string $text
      * @return string
      */


### PR DESCRIPTION
Mentioned in discussion of
https://github.com/Microsoft/tolerant-php-parser/pull/136/files 
(Couldn't find the code style guidelines referred to, if any. Is that just referring to the current state?)

Many IDEs and tools don't expect whitespace, and don't handle this.
So, they may act as if only the first type.

- https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types
  is a proposal, and is vague about how whitespace is handled
  outside `<>`
- https://github.com/phpDocumentor/phpDocumentor2/blob/develop/docs/references/phpdoc/tags/var.rst
  is vague
- https://github.com/phpDocumentor/ReflectionDocBlock/blob/master/src/DocBlock/Tags/Var_.php
  doesn't expect any whitespace after `@var`