### PR TITLE
Make phpdoc of Node and its subclasses more accurate

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -78,7 +78,7 @@ abstract class Node implements \JsonSerializable {
      * Gets first ancestor that is an instance of one of the provided classes.
      * Returns null if there is no match.
      *
-     * @param array ...$classNames
+     * @param string ...$classNames
      * @return Node|null
      */
     public function getFirstAncestor(...$classNames) {
@@ -139,7 +139,7 @@ abstract class Node implements \JsonSerializable {
 
     /**
      * Gets root of the syntax tree (returns self if has no parents)
-     * @return Node
+     * @return SourceFileNode (expect root to be SourceFileNode unless the tree was manipulated)
      */
     public function getRoot() : Node {
         $node = $this;
@@ -450,7 +450,7 @@ abstract class Node implements \JsonSerializable {
      * @throws \Exception
      */
     public function getImportTablesForCurrentScope() {
-        $namespaceDefinition = $namespaceDefinition ?? $this->getNamespaceDefinition();
+        $namespaceDefinition = $this->getNamespaceDefinition();
 
         // Use declarations can exist in either the global scope, or inside namespace declarations.
         // http://php.net/manual/en/language.namespaces.importing.php#language.namespaces.importing.scope

--- a/src/Node/Expression/EchoExpression.php
+++ b/src/Node/Expression/EchoExpression.php
@@ -7,6 +7,7 @@
 namespace Microsoft\PhpParser\Node\Expression;
 
 use Microsoft\PhpParser\Node\Expression;
+use Microsoft\PhpParser\Node\DelimitedList\ExpressionList;
 use Microsoft\PhpParser\Token;
 
 class EchoExpression extends Expression {
@@ -14,7 +15,7 @@ class EchoExpression extends Expression {
     /** @var Token */
     public $echoKeyword;
 
-    /** @var Expression[] */
+    /** @var ExpressionList */
     public $expressions;
 
     const CHILD_NAMES = [

--- a/src/Node/NumericLiteral.php
+++ b/src/Node/NumericLiteral.php
@@ -9,7 +9,7 @@ namespace Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;
 
 class NumericLiteral extends Expression {
-    /** @var Token[] */
+    /** @var Token */
     public $children;
 
     const CHILD_NAMES = [

--- a/src/Node/QualifiedName.php
+++ b/src/Node/QualifiedName.php
@@ -157,7 +157,7 @@ class QualifiedName extends Node implements NamespacedNameInterface {
     /**
      * @param ResolvedName[] $importTable
      * @param bool $isCaseSensitive
-     * @return null
+     * @return string|null
      */
     private function tryResolveFromImportTable($importTable, bool $isCaseSensitive = false) {
         $content = $this->getFileContents();

--- a/src/Node/ReservedWord.php
+++ b/src/Node/ReservedWord.php
@@ -9,7 +9,7 @@ namespace Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;
 
 class ReservedWord extends Expression {
-    /** @var Token[] */
+    /** @var Token */
     public $children;
 
     const CHILD_NAMES = [

--- a/src/Node/StringLiteral.php
+++ b/src/Node/StringLiteral.php
@@ -13,7 +13,7 @@ class StringLiteral extends Expression {
     /** @var Token */
     public $startQuote;
 
-    /** @var Token[] | Node[] */
+    /** @var Token[]|Node[]|Token */
     public $children;
 
     /** @var Token */


### PR DESCRIPTION
- Some node subclasses have `Token` (not an array) as `$this->children`
- Undefined variable in coalesce
- be more specific about getRoot()'s expected value.
- use string ...$classNames (same syntax as a real signature)
  https://github.com/phpDocumentor/fig-standards/pull/87#r37054459
- EchoExpression has ExpressionList (no expressions would be invalid PHP)
- One form of string literal can be a single token, others (e.g. `"something $varName"` may have multiple tokens and expressions)