### PR TITLE
Stop including non-php files in validation tests.

### DIFF
--- a/tests/ParserFrameworkValidationTests.php
+++ b/tests/ParserFrameworkValidationTests.php
@@ -18,9 +18,11 @@ class ParserFrameworkValidationTests extends TestCase {
             $iterator = new RecursiveDirectoryIterator(__DIR__ . "/../validation/frameworks/" . $frameworkName);
 
             foreach (new RecursiveIteratorIterator($iterator) as $file) {
-                if (strpos($file, ".php") !== false) {
+                $pathName = $file->getPathname();
+                if (preg_match('@\.php$@', $pathName) > 0) {
+                    // Include files ending in ".php", but don't include XML(foo.phpunit.xml) or binary files (foo.php.gz)
                     $totalSize += $file->getSize();
-                    $testProviderArray[$frameworkName . "::" . $file->getBasename()] = [$file->getPathname(), $frameworkName];
+                    $testProviderArray[$frameworkName . "::" . $file->getBasename()] = [$pathName, $frameworkName];
                 }
             }
         }
@@ -33,7 +35,7 @@ class ParserFrameworkValidationTests extends TestCase {
     /**
      * @dataProvider frameworkErrorProvider
      */
-    public function testFramworkErrors($testCaseFile, $frameworkName) {
+    public function testFrameworkErrors($testCaseFile, $frameworkName) {
         $fileContents = file_get_contents($testCaseFile);
         $parser = new \Microsoft\PhpParser\Parser();
         $sourceFile = $parser->parseSourceFile($fileContents);
@@ -51,8 +53,8 @@ class ParserFrameworkValidationTests extends TestCase {
         foreach ($sourceFile->getDescendantNodesAndTokens() as $child) {
             if ($child instanceof Token) {
                 $this->assertNotEquals(\Microsoft\PhpParser\TokenKind::Unknown, $child->kind, "input: $testCaseFile\r\nexpected: ");
-                $this->assertNotTrue($child instanceof \Microsoft\PhpParser\SkippedToken, "input: $testCaseFile\r\nexpected: ");
-                $this->assertNotTrue($child instanceof \Microsoft\PhpParser\MissingToken, "input: $testCaseFile\r\nexpected: ");
+                $this->assertNotInstanceOf(\Microsoft\PhpParser\SkippedToken::class, $child, "input: $testCaseFile\r\nexpected: ");
+                $this->assertNotInstanceOf(\Microsoft\PhpParser\MissingToken::class, $child, "input: $testCaseFile\r\nexpected: ");
             }
         }
 

--- a/tests/ParserFrameworkValidationTests.php
+++ b/tests/ParserFrameworkValidationTests.php
@@ -19,7 +19,7 @@ class ParserFrameworkValidationTests extends TestCase {
 
             foreach (new RecursiveIteratorIterator($iterator) as $file) {
                 $pathName = $file->getPathname();
-                if (preg_match('@\.php$@', $pathName) > 0) {
+                if (preg_match('/\.php$/', $pathName) > 0) {
                     // Include files ending in ".php", but don't include XML(foo.phpunit.xml) or binary files (foo.php.gz)
                     $totalSize += $file->getSize();
                     $testProviderArray[$frameworkName . "::" . $file->getBasename()] = [$pathName, $frameworkName];


### PR DESCRIPTION
Noticed test failures for pgsql.phpunit.xml in the drupal project's test
files. (contains the substring ".php").
That also included `foo.php.gz`

Also, do the matching on the path name, not on the object to string
conversion.