### PR TITLE
Speed up token value to name lookup

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -59,15 +59,25 @@ class Token implements \JsonSerializable {
         return $this->fullStart + $this->length;
     }
 
-    public static function getTokenKindNameFromValue($kindName) {
-        $constants = (new \ReflectionClass("Microsoft\\PhpParser\\TokenKind"))->getConstants();
-        foreach ($constants as $name => $val) {
-            if ($val == $kindName) {
-                $kindName = $name;
-                break;
-            }
+    /**
+     * @return string[] - A hash map of the format [int $tokenKind => string $tokenName]
+     */
+    private static function getTokenKindNameFromValueMap() {
+        static $mapToKindName;
+        if ($mapToKindName === null) {
+            $constants = (new \ReflectionClass("Microsoft\\PhpParser\\TokenKind"))->getConstants();
+            $mapToKindName = \array_flip($constants);
         }
-        return $kindName;
+        return $mapToKindName;
+    }
+
+    /**
+     * @param int $kind
+     * @return string (Or int, if the kind name for $kind wasn't found)
+     */
+    public static function getTokenKindNameFromValue($kind) {
+        $mapToKindName = self::getTokenKindNameFromValueMap();
+        return $mapToKindName[$kind] ?? $kind;
     }
 
     public function jsonSerialize() {


### PR DESCRIPTION
Grammar test suite sped up from 1.2 seconds to 1.1 seconds.

This went from O(n) (loop over (around half of) 183 constants) to O(1) (hash lookup)