### PR TITLE
README: make require use of __DIR__

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ with the Abstract Syntax Tree (AST) via a friendly API.
 ```php
 <?php
 // Autoload required classes
-require "vendor/autoload.php";
+require __DIR__ . "/vendor/autoload.php";
 
 use Microsoft\PhpParser\{DiagnosticsProvider, Node, Parser, PositionUtilities};
 


### PR DESCRIPTION
When we now absolute path, it's better to use it