### PR TITLE
Minor performance improvement: Add faster variant of eat()

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -148,7 +148,7 @@ class Parser {
         $this->reset();
 
         $sourceFile = new SourceFileNode();
-        $this->sourceFile = & $sourceFile;
+        $this->sourceFile = $sourceFile;
         $sourceFile->fileContents = $fileContents;
         $sourceFile->uri = $uri;
         $sourceFile->statementList = array();
@@ -158,7 +158,7 @@ class Parser {
         $sourceFile->statementList =
             \array_merge($sourceFile->statementList, $this->parseList($sourceFile, ParseContext::SourceElements));
 
-        $this->sourceFile->endOfFileToken = $this->eat(TokenKind::EndOfFileToken);
+        $this->sourceFile->endOfFileToken = $this->eat1(TokenKind::EndOfFileToken);
         $this->advanceToken();
 
         $sourceFile->parent = null;
@@ -386,6 +386,26 @@ class Parser {
     }
 
     /**
+     * Retrieve the current token, and check that it's of the kind $kind.
+     * If so, advance and return the token. Otherwise return a MissingToken for
+     * the expected token.
+     *
+     * This is faster than calling eat() if there is a single token.
+     *
+     * @param int $kind
+     * @return Token
+     */
+    private function eat1($kind) {
+        $token = $this->token;
+        if ($token->kind === $kind) {
+            $this->token = $this->lexer->scanNextToken();
+            return $token;
+        }
+        // TODO include optional grouping for token kinds
+        return new MissingToken($kind, $token->fullStart);
+    }
+
+    /**
      * @param int|int[] ...$kinds (Can provide a single value with a list of kinds, or multiple kinds)
      * @return Token|null
      */
@@ -395,6 +415,19 @@ class Parser {
             $kinds = $kinds[0];
         }
         if (\in_array($token->kind, $kinds)) {
+            $this->token = $this->lexer->scanNextToken();
+            return $token;
+        }
+        return null;
+    }
+
+    /**
+     * @param int $kind a single kind
+     * @return Token|null
+     */
+    private function eatOptional1($kind) {
+        $token = $this->token;
+        if ($token->kind === $kind) {
             $this->token = $this->lexer->scanNextToken();
             return $token;
         }
@@ -565,7 +598,7 @@ class Parser {
         $classNode = new ClassDeclaration(); // TODO verify not nested
         $classNode->parent = $parentNode;
         $classNode->abstractOrFinalModifier = $this->eatOptional(TokenKind::AbstractKeyword, TokenKind::FinalKeyword);
-        $classNode->classKeyword = $this->eat(TokenKind::ClassKeyword);
+        $classNode->classKeyword = $this->eat1(TokenKind::ClassKeyword);
         $classNode->name = $this->eat($this->nameOrReservedWordTokens); // TODO should be any
         $classNode->name->kind = TokenKind::Name;
         $classNode->classBaseClause = $this->parseClassBaseClause($classNode);
@@ -576,9 +609,9 @@ class Parser {
 
     private function parseClassMembers($parentNode) : Node {
         $classMembers = new ClassMembersNode();
-        $classMembers->openBrace = $this->eat(TokenKind::OpenBraceToken);
+        $classMembers->openBrace = $this->eat1(TokenKind::OpenBraceToken);
         $classMembers->classMemberDeclarations = $this->parseList($classMembers, ParseContext::ClassMembers);
-        $classMembers->closeBrace = $this->eat(TokenKind::CloseBraceToken);
+        $classMembers->closeBrace = $this->eat1(TokenKind::CloseBraceToken);
         $classMembers->parent = $parentNode;
         return $classMembers;
     }
@@ -602,14 +635,14 @@ class Parser {
         return function ($parentNode) {
             $parameter = new Parameter();
             $parameter->parent = $parentNode;
-            $parameter->questionToken = $this->eatOptional(TokenKind::QuestionToken);
+            $parameter->questionToken = $this->eatOptional1(TokenKind::QuestionToken);
             $parameter->typeDeclaration = $this->tryParseParameterTypeDeclaration($parameter);
-            $parameter->byRefToken = $this->eatOptional(TokenKind::AmpersandToken);
+            $parameter->byRefToken = $this->eatOptional1(TokenKind::AmpersandToken);
             // TODO add post-parse rule that prevents assignment
             // TODO add post-parse rule that requires only last parameter be variadic
-            $parameter->dotDotDotToken = $this->eatOptional(TokenKind::DotDotDotToken);
-            $parameter->variableName = $this->eat(TokenKind::VariableName);
-            $parameter->equalsToken = $this->eatOptional(TokenKind::EqualsToken);
+            $parameter->dotDotDotToken = $this->eatOptional1(TokenKind::DotDotDotToken);
+            $parameter->variableName = $this->eat1(TokenKind::VariableName);
+            $parameter->equalsToken = $this->eatOptional1(TokenKind::EqualsToken);
             if ($parameter->equalsToken !== null) {
                 // TODO add post-parse rule that checks for invalid assignments
                 $parameter->default = $this->parseExpression($parameter);
@@ -635,9 +668,9 @@ class Parser {
 
     private function parseCompoundStatement($parentNode) {
         $compoundStatement = new CompoundStatementNode();
-        $compoundStatement->openBrace = $this->eat(TokenKind::OpenBraceToken);
+        $compoundStatement->openBrace = $this->eat1(TokenKind::OpenBraceToken);
         $compoundStatement->statements =  $this->parseList($compoundStatement, ParseContext::BlockStatements);
-        $compoundStatement->closeBrace = $this->eat(TokenKind::CloseBraceToken);
+        $compoundStatement->closeBrace = $this->eat1(TokenKind::CloseBraceToken);
         $compoundStatement->parent = $parentNode;
         return $compoundStatement;
     }
@@ -955,7 +988,7 @@ class Parser {
     private function parseEmptyStatement($parentNode) {
         $emptyStatement = new EmptyStatement();
         $emptyStatement->parent = $parentNode;
-        $emptyStatement->semicolon = $this->eat(TokenKind::SemicolonToken);
+        $emptyStatement->semicolon = $this->eat1(TokenKind::SemicolonToken);
         return $emptyStatement;
     }
 
@@ -985,7 +1018,7 @@ class Parser {
                     } else {
                         $expression->children[] = $this->parseExpression($expression);
                     }
-                    $expression->children[] = $this->eat(TokenKind::CloseBraceToken);
+                    $expression->children[] = $this->eat1(TokenKind::CloseBraceToken);
                     continue;
                 case $startQuoteKind = $expression->startQuote->kind:
                 case TokenKind::EndOfFileToken:
@@ -1034,7 +1067,7 @@ class Parser {
         $postfixExpression->parent = $subscriptExpression;
 
         $subscriptExpression->postfixExpression = $postfixExpression;
-        $subscriptExpression->openBracketOrBrace = $this->eat(TokenKind::OpenBracketToken); // Only [] syntax is supported, not {}
+        $subscriptExpression->openBracketOrBrace = $this->eat1(TokenKind::OpenBracketToken); // Only [] syntax is supported, not {}
         $token = $this->getCurrentToken();
         if ($token->kind === TokenKind::VariableName) {
             $subscriptExpression->accessExpression = $this->parseSimpleVariable($subscriptExpression);
@@ -1046,7 +1079,7 @@ class Parser {
             $subscriptExpression->accessExpression = new MissingToken(TokenKind::Expression, $token->fullStart);
         }
 
-        $subscriptExpression->closeBracketOrBrace = $this->eat(TokenKind::CloseBracketToken);
+        $subscriptExpression->closeBracketOrBrace = $this->eat1(TokenKind::CloseBracketToken);
 
         return $subscriptExpression;
     }
@@ -1054,7 +1087,7 @@ class Parser {
     private function parseTemplateStringSubscriptStringLiteral($parentNode) : StringLiteral {
         $expression = new StringLiteral();
         $expression->parent = $parentNode;
-        $expression->children = $this->eat(TokenKind::Name);
+        $expression->children = $this->eat1(TokenKind::Name);
         return $expression;
     }
 
@@ -1064,8 +1097,8 @@ class Parser {
         $expression->parent = $memberAccessExpression;
 
         $memberAccessExpression->dereferencableExpression = $expression;
-        $memberAccessExpression->arrowToken = $this->eat(TokenKind::ArrowToken);
-        $memberAccessExpression->memberName = $this->eat(TokenKind::Name);
+        $memberAccessExpression->arrowToken = $this->eat1(TokenKind::ArrowToken);
+        $memberAccessExpression->memberName = $this->eat1(TokenKind::Name);
 
         return $memberAccessExpression;
     }
@@ -1205,7 +1238,7 @@ class Parser {
             $node->parent = $parentNode;
             $node->relativeSpecifier = $this->parseRelativeSpecifier($node);
             if (!isset($node->relativeSpecifier)) {
-                $node->globalSpecifier = $this->eatOptional(TokenKind::BackslashToken);
+                $node->globalSpecifier = $this->eatOptional1(TokenKind::BackslashToken);
             }
 
             $nameParts =
@@ -1244,9 +1277,9 @@ class Parser {
     private function parseRelativeSpecifier($parentNode) {
         $node = new RelativeSpecifier();
         $node->parent = $parentNode;
-        $node->namespaceKeyword = $this->eatOptional(TokenKind::NamespaceKeyword);
+        $node->namespaceKeyword = $this->eatOptional1(TokenKind::NamespaceKeyword);
         if ($node->namespaceKeyword !== null) {
-            $node->backslash = $this->eat(TokenKind::BackslashToken);
+            $node->backslash = $this->eat1(TokenKind::BackslashToken);
         }
         if (isset($node->backslash)) {
             return $node;
@@ -1255,8 +1288,8 @@ class Parser {
     }
 
     private function parseFunctionType(Node $functionDeclaration, $canBeAbstract = false, $isAnonymous = false) {
-        $functionDeclaration->functionKeyword = $this->eat(TokenKind::FunctionKeyword);
-        $functionDeclaration->byRefToken = $this->eatOptional(TokenKind::AmpersandToken);
+        $functionDeclaration->functionKeyword = $this->eat1(TokenKind::FunctionKeyword);
+        $functionDeclaration->byRefToken = $this->eatOptional1(TokenKind::AmpersandToken);
         $functionDeclaration->name = $isAnonymous
             ? $this->eatOptional($this->nameOrKeywordOrReservedWordTokens)
             : $this->eat($this->nameOrKeywordOrReservedWordTokens);
@@ -1270,26 +1303,26 @@ class Parser {
             $functionDeclaration->name = new SkippedToken($functionDeclaration->name); // TODO instaed handle this during post-walk
         }
 
-        $functionDeclaration->openParen = $this->eat(TokenKind::OpenParenToken);
+        $functionDeclaration->openParen = $this->eat1(TokenKind::OpenParenToken);
         $functionDeclaration->parameters = $this->parseDelimitedList(
             DelimitedList\ParameterDeclarationList::class,
             TokenKind::CommaToken,
             $this->isParameterStartFn(),
             $this->parseParameterFn(),
             $functionDeclaration);
-        $functionDeclaration->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $functionDeclaration->closeParen = $this->eat1(TokenKind::CloseParenToken);
         if ($isAnonymous) {
             $functionDeclaration->anonymousFunctionUseClause = $this->parseAnonymousFunctionUseClause($functionDeclaration);
         }
 
         if ($this->checkToken(TokenKind::ColonToken)) {
-            $functionDeclaration->colonToken = $this->eat(TokenKind::ColonToken);
-            $functionDeclaration->questionToken = $this->eatOptional(TokenKind::QuestionToken);
+            $functionDeclaration->colonToken = $this->eat1(TokenKind::ColonToken);
+            $functionDeclaration->questionToken = $this->eatOptional1(TokenKind::QuestionToken);
             $functionDeclaration->returnType = $this->parseReturnTypeDeclaration($functionDeclaration);
         }
 
         if ($canBeAbstract) {
-            $functionDeclaration->compoundStatementOrSemicolon = $this->eatOptional(TokenKind::SemicolonToken);
+            $functionDeclaration->compoundStatementOrSemicolon = $this->eatOptional1(TokenKind::SemicolonToken);
         }
 
         if (!isset($functionDeclaration->compoundStatementOrSemicolon)) {
@@ -1300,8 +1333,8 @@ class Parser {
     private function parseNamedLabelStatement($parentNode) {
         $namedLabelStatement = new NamedLabelStatement();
         $namedLabelStatement->parent = $parentNode;
-        $namedLabelStatement->name = $this->eat(TokenKind::Name);
-        $namedLabelStatement->colon = $this->eat(TokenKind::ColonToken);
+        $namedLabelStatement->name = $this->eat1(TokenKind::Name);
+        $namedLabelStatement->colon = $this->eat1(TokenKind::ColonToken);
         $namedLabelStatement->statement = $this->parseStatement($namedLabelStatement);
         return $namedLabelStatement;
     }
@@ -1341,12 +1374,12 @@ class Parser {
     private function parseIfStatement($parentNode) {
         $ifStatement = new IfStatementNode();
         $ifStatement->parent = $parentNode;
-        $ifStatement->ifKeyword = $this->eat(TokenKind::IfKeyword);
-        $ifStatement->openParen = $this->eat(TokenKind::OpenParenToken);
+        $ifStatement->ifKeyword = $this->eat1(TokenKind::IfKeyword);
+        $ifStatement->openParen = $this->eat1(TokenKind::OpenParenToken);
         $ifStatement->expression = $this->parseExpression($ifStatement);
-        $ifStatement->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $ifStatement->closeParen = $this->eat1(TokenKind::CloseParenToken);
         if ($this->checkToken(TokenKind::ColonToken)) {
-            $ifStatement->colon = $this->eat(TokenKind::ColonToken);
+            $ifStatement->colon = $this->eat1(TokenKind::ColonToken);
             $ifStatement->statements = $this->parseList($ifStatement, ParseContext::IfClause2Elements);
         } else {
             $ifStatement->statements = $this->parseStatement($ifStatement);
@@ -1360,7 +1393,7 @@ class Parser {
             $ifStatement->elseClause = $this->parseElseClause($ifStatement);
         }
 
-        $ifStatement->endifKeyword = $this->eatOptional(TokenKind::EndIfKeyword);
+        $ifStatement->endifKeyword = $this->eatOptional1(TokenKind::EndIfKeyword);
         if ($ifStatement->endifKeyword) {
             $ifStatement->semicolon = $this->eatSemicolonOrAbortStatement();
         }
@@ -1371,12 +1404,12 @@ class Parser {
     private function parseElseIfClause($parentNode) {
         $elseIfClause = new ElseIfClauseNode();
         $elseIfClause->parent = $parentNode;
-        $elseIfClause->elseIfKeyword = $this->eat(TokenKind::ElseIfKeyword);
-        $elseIfClause->openParen = $this->eat(TokenKind::OpenParenToken);
+        $elseIfClause->elseIfKeyword = $this->eat1(TokenKind::ElseIfKeyword);
+        $elseIfClause->openParen = $this->eat1(TokenKind::OpenParenToken);
         $elseIfClause->expression = $this->parseExpression($elseIfClause);
-        $elseIfClause->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $elseIfClause->closeParen = $this->eat1(TokenKind::CloseParenToken);
         if ($this->checkToken(TokenKind::ColonToken)) {
-            $elseIfClause->colon = $this->eat(TokenKind::ColonToken);
+            $elseIfClause->colon = $this->eat1(TokenKind::ColonToken);
             $elseIfClause->statements = $this->parseList($elseIfClause, ParseContext::IfClause2Elements);
         } else {
             $elseIfClause->statements = $this->parseStatement($elseIfClause);
@@ -1387,9 +1420,9 @@ class Parser {
     private function parseElseClause($parentNode) {
         $elseClause = new ElseClauseNode();
         $elseClause->parent = $parentNode;
-        $elseClause->elseKeyword = $this->eat(TokenKind::ElseKeyword);
+        $elseClause->elseKeyword = $this->eat1(TokenKind::ElseKeyword);
         if ($this->checkToken(TokenKind::ColonToken)) {
-            $elseClause->colon = $this->eat(TokenKind::ColonToken);
+            $elseClause->colon = $this->eat1(TokenKind::ColonToken);
             $elseClause->statements = $this->parseList($elseClause, ParseContext::IfClause2Elements);
         } else {
             $elseClause->statements = $this->parseStatement($elseClause);
@@ -1400,18 +1433,18 @@ class Parser {
     private function parseSwitchStatement($parentNode) {
         $switchStatement = new SwitchStatementNode();
         $switchStatement->parent = $parentNode;
-        $switchStatement->switchKeyword = $this->eat(TokenKind::SwitchKeyword);
-        $switchStatement->openParen = $this->eat(TokenKind::OpenParenToken);
+        $switchStatement->switchKeyword = $this->eat1(TokenKind::SwitchKeyword);
+        $switchStatement->openParen = $this->eat1(TokenKind::OpenParenToken);
         $switchStatement->expression = $this->parseExpression($switchStatement);
-        $switchStatement->closeParen = $this->eat(TokenKind::CloseParenToken);
-        $switchStatement->openBrace = $this->eatOptional(TokenKind::OpenBraceToken);
-        $switchStatement->colon = $this->eatOptional(TokenKind::ColonToken);
+        $switchStatement->closeParen = $this->eat1(TokenKind::CloseParenToken);
+        $switchStatement->openBrace = $this->eatOptional1(TokenKind::OpenBraceToken);
+        $switchStatement->colon = $this->eatOptional1(TokenKind::ColonToken);
         $switchStatement->caseStatements = $this->parseList($switchStatement, ParseContext::SwitchStatementElements);
         if ($switchStatement->colon !== null) {
-            $switchStatement->endswitch = $this->eat(TokenKind::EndSwitchKeyword);
+            $switchStatement->endswitch = $this->eat1(TokenKind::EndSwitchKeyword);
             $switchStatement->semicolon = $this->eatSemicolonOrAbortStatement();
         } else {
-            $switchStatement->closeBrace = $this->eat(TokenKind::CloseBraceToken);
+            $switchStatement->closeBrace = $this->eat1(TokenKind::CloseBraceToken);
         }
 
         return $switchStatement;
@@ -1435,14 +1468,14 @@ class Parser {
     private function parseWhileStatement($parentNode) {
         $whileStatement = new WhileStatement();
         $whileStatement->parent = $parentNode;
-        $whileStatement->whileToken = $this->eat(TokenKind::WhileKeyword);
-        $whileStatement->openParen = $this->eat(TokenKind::OpenParenToken);
+        $whileStatement->whileToken = $this->eat1(TokenKind::WhileKeyword);
+        $whileStatement->openParen = $this->eat1(TokenKind::OpenParenToken);
         $whileStatement->expression = $this->parseExpression($whileStatement);
-        $whileStatement->closeParen = $this->eat(TokenKind::CloseParenToken);
-        $whileStatement->colon = $this->eatOptional(TokenKind::ColonToken);
+        $whileStatement->closeParen = $this->eat1(TokenKind::CloseParenToken);
+        $whileStatement->colon = $this->eatOptional1(TokenKind::ColonToken);
         if ($whileStatement->colon !== null) {
             $whileStatement->statements = $this->parseList($whileStatement, ParseContext::WhileStatementElements);
-            $whileStatement->endWhile = $this->eat(TokenKind::EndWhileKeyword);
+            $whileStatement->endWhile = $this->eat1(TokenKind::EndWhileKeyword);
             $whileStatement->semicolon = $this->eatSemicolonOrAbortStatement();
         } else {
             $whileStatement->statements = $this->parseStatement($whileStatement);
@@ -1642,7 +1675,7 @@ class Parser {
             $this->advanceToken();
 
             if ($token->kind === TokenKind::EqualsToken) {
-                $byRefToken = $this->eatOptional(TokenKind::AmpersandToken);
+                $byRefToken = $this->eatOptional1(TokenKind::AmpersandToken);
             }
 
             $leftOperand = $token->kind === TokenKind::QuestionToken ?
@@ -1783,12 +1816,12 @@ class Parser {
     private function parseDoStatement($parentNode) {
         $doStatement = new DoStatement();
         $doStatement->parent = $parentNode;
-        $doStatement->do = $this->eat(TokenKind::DoKeyword);
+        $doStatement->do = $this->eat1(TokenKind::DoKeyword);
         $doStatement->statement = $this->parseStatement($doStatement);
-        $doStatement->whileToken = $this->eat(TokenKind::WhileKeyword);
-        $doStatement->openParen = $this->eat(TokenKind::OpenParenToken);
+        $doStatement->whileToken = $this->eat1(TokenKind::WhileKeyword);
+        $doStatement->openParen = $this->eat1(TokenKind::OpenParenToken);
         $doStatement->expression = $this->parseExpression($doStatement);
-        $doStatement->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $doStatement->closeParen = $this->eat1(TokenKind::CloseParenToken);
         $doStatement->semicolon = $this->eatSemicolonOrAbortStatement();
         return $doStatement;
     }
@@ -1796,18 +1829,18 @@ class Parser {
     private function parseForStatement($parentNode) {
         $forStatement = new ForStatement();
         $forStatement->parent = $parentNode;
-        $forStatement->for = $this->eat(TokenKind::ForKeyword);
-        $forStatement->openParen = $this->eat(TokenKind::OpenParenToken);
+        $forStatement->for = $this->eat1(TokenKind::ForKeyword);
+        $forStatement->openParen = $this->eat1(TokenKind::OpenParenToken);
         $forStatement->forInitializer = $this->parseExpressionList($forStatement); // TODO spec is redundant
-        $forStatement->exprGroupSemicolon1 = $this->eat(TokenKind::SemicolonToken);
+        $forStatement->exprGroupSemicolon1 = $this->eat1(TokenKind::SemicolonToken);
         $forStatement->forControl = $this->parseExpressionList($forStatement);
-        $forStatement->exprGroupSemicolon2 = $this->eat(TokenKind::SemicolonToken);
+        $forStatement->exprGroupSemicolon2 = $this->eat1(TokenKind::SemicolonToken);
         $forStatement->forEndOfLoop = $this->parseExpressionList($forStatement);
-        $forStatement->closeParen = $this->eat(TokenKind::CloseParenToken);
-        $forStatement->colon = $this->eatOptional(TokenKind::ColonToken);
+        $forStatement->closeParen = $this->eat1(TokenKind::CloseParenToken);
+        $forStatement->colon = $this->eatOptional1(TokenKind::ColonToken);
         if ($forStatement->colon !== null) {
             $forStatement->statements = $this->parseList($forStatement, ParseContext::ForStatementElements);
-            $forStatement->endFor = $this->eat(TokenKind::EndForKeyword);
+            $forStatement->endFor = $this->eat1(TokenKind::EndForKeyword);
             $forStatement->endForSemicolon = $this->eatSemicolonOrAbortStatement();
         } else {
             $forStatement->statements = $this->parseStatement($forStatement);
@@ -1818,17 +1851,17 @@ class Parser {
     private function parseForeachStatement($parentNode) {
         $foreachStatement = new ForeachStatement();
         $foreachStatement->parent = $parentNode;
-        $foreachStatement->foreach = $this->eat(TokenKind::ForeachKeyword);
-        $foreachStatement->openParen = $this->eat(TokenKind::OpenParenToken);
+        $foreachStatement->foreach = $this->eat1(TokenKind::ForeachKeyword);
+        $foreachStatement->openParen = $this->eat1(TokenKind::OpenParenToken);
         $foreachStatement->forEachCollectionName = $this->parseExpression($foreachStatement);
-        $foreachStatement->asKeyword = $this->eat(TokenKind::AsKeyword);
+        $foreachStatement->asKeyword = $this->eat1(TokenKind::AsKeyword);
         $foreachStatement->foreachKey = $this->tryParseForeachKey($foreachStatement);
         $foreachStatement->foreachValue = $this->parseForeachValue($foreachStatement);
-        $foreachStatement->closeParen = $this->eat(TokenKind::CloseParenToken);
-        $foreachStatement->colon = $this->eatOptional(TokenKind::ColonToken);
+        $foreachStatement->closeParen = $this->eat1(TokenKind::CloseParenToken);
+        $foreachStatement->colon = $this->eatOptional1(TokenKind::ColonToken);
         if ($foreachStatement->colon !== null) {
             $foreachStatement->statements = $this->parseList($foreachStatement, ParseContext::ForeachStatementElements);
-            $foreachStatement->endForeach = $this->eat(TokenKind::EndForEachKeyword);
+            $foreachStatement->endForeach = $this->eat1(TokenKind::EndForEachKeyword);
             $foreachStatement->endForeachSemicolon = $this->eatSemicolonOrAbortStatement();
         } else {
             $foreachStatement->statements = $this->parseStatement($foreachStatement);
@@ -1853,14 +1886,14 @@ class Parser {
             return null;
         }
 
-        $foreachKey->arrow = $this->eat(TokenKind::DoubleArrowToken);
+        $foreachKey->arrow = $this->eat1(TokenKind::DoubleArrowToken);
         return $foreachKey;
     }
 
     private function parseForeachValue($parentNode) {
         $foreachValue = new ForeachValue();
         $foreachValue->parent = $parentNode;
-        $foreachValue->ampersand = $this->eatOptional(TokenKind::AmpersandToken);
+        $foreachValue->ampersand = $this->eatOptional1(TokenKind::AmpersandToken);
         $foreachValue->expression = $this->parseExpression($foreachValue);
         return $foreachValue;
     }
@@ -1868,8 +1901,8 @@ class Parser {
     private function parseGotoStatement($parentNode) {
         $gotoStatement = new GotoStatement();
         $gotoStatement->parent = $parentNode;
-        $gotoStatement->goto = $this->eat(TokenKind::GotoKeyword);
-        $gotoStatement->name = $this->eat(TokenKind::Name);
+        $gotoStatement->goto = $this->eat1(TokenKind::GotoKeyword);
+        $gotoStatement->name = $this->eat1(TokenKind::Name);
         $gotoStatement->semicolon = $this->eatSemicolonOrAbortStatement();
         return $gotoStatement;
     }
@@ -1892,7 +1925,7 @@ class Parser {
     private function parseReturnStatement($parentNode) {
         $returnStatement = new ReturnStatement();
         $returnStatement->parent = $parentNode;
-        $returnStatement->returnKeyword = $this->eat(TokenKind::ReturnKeyword);
+        $returnStatement->returnKeyword = $this->eat1(TokenKind::ReturnKeyword);
         if ($this->isExpressionStart($this->getCurrentToken())) {
             $returnStatement->expression = $this->parseExpression($returnStatement);
         }
@@ -1904,7 +1937,7 @@ class Parser {
     private function parseThrowStatement($parentNode) {
         $throwStatement = new ThrowStatement();
         $throwStatement->parent = $parentNode;
-        $throwStatement->throwKeyword = $this->eat(TokenKind::ThrowKeyword);
+        $throwStatement->throwKeyword = $this->eat1(TokenKind::ThrowKeyword);
         // TODO error for failures to parse expressions when not optional
         $throwStatement->expression = $this->parseExpression($throwStatement);
         $throwStatement->semicolon = $this->eatSemicolonOrAbortStatement();
@@ -1915,7 +1948,7 @@ class Parser {
     private function parseTryStatement($parentNode) {
         $tryStatement = new TryStatement();
         $tryStatement->parent = $parentNode;
-        $tryStatement->tryKeyword = $this->eat(TokenKind::TryKeyword);
+        $tryStatement->tryKeyword = $this->eat1(TokenKind::TryKeyword);
         $tryStatement->compoundStatement = $this->parseCompoundStatement($tryStatement); // TODO verifiy this is only compound
 
         $tryStatement->catchClauses = array(); // TODO - should be some standard for empty arrays vs. null?
@@ -1933,11 +1966,11 @@ class Parser {
     private function parseCatchClause($parentNode) {
         $catchClause = new CatchClause();
         $catchClause->parent = $parentNode;
-        $catchClause->catch = $this->eat(TokenKind::CatchKeyword);
-        $catchClause->openParen = $this->eat(TokenKind::OpenParenToken);
+        $catchClause->catch = $this->eat1(TokenKind::CatchKeyword);
+        $catchClause->openParen = $this->eat1(TokenKind::OpenParenToken);
         $catchClause->qualifiedName = $this->parseQualifiedName($catchClause); // TODO generate missing token or error if null
-        $catchClause->variableName = $this->eat(TokenKind::VariableName);
-        $catchClause->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $catchClause->variableName = $this->eat1(TokenKind::VariableName);
+        $catchClause->closeParen = $this->eat1(TokenKind::CloseParenToken);
         $catchClause->compoundStatement = $this->parseCompoundStatement($catchClause);
 
         return $catchClause;
@@ -1946,7 +1979,7 @@ class Parser {
     private function parseFinallyClause($parentNode) {
         $finallyClause = new FinallyClause();
         $finallyClause->parent = $parentNode;
-        $finallyClause->finallyToken = $this->eat(TokenKind::FinallyKeyword);
+        $finallyClause->finallyToken = $this->eat1(TokenKind::FinallyKeyword);
         $finallyClause->compoundStatement = $this->parseCompoundStatement($finallyClause);
 
         return $finallyClause;
@@ -1955,17 +1988,17 @@ class Parser {
     private function parseDeclareStatement($parentNode) {
         $declareStatement = new DeclareStatement();
         $declareStatement->parent = $parentNode;
-        $declareStatement->declareKeyword = $this->eat(TokenKind::DeclareKeyword);
-        $declareStatement->openParen = $this->eat(TokenKind::OpenParenToken);
+        $declareStatement->declareKeyword = $this->eat1(TokenKind::DeclareKeyword);
+        $declareStatement->openParen = $this->eat1(TokenKind::OpenParenToken);
         $declareStatement->declareDirective = $this->parseDeclareDirective($declareStatement);
-        $declareStatement->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $declareStatement->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         if ($this->checkToken(TokenKind::SemicolonToken)) {
             $declareStatement->semicolon = $this->eatSemicolonOrAbortStatement();
         } elseif ($this->checkToken(TokenKind::ColonToken)) {
-            $declareStatement->colon = $this->eat(TokenKind::ColonToken);
+            $declareStatement->colon = $this->eat1(TokenKind::ColonToken);
             $declareStatement->statements = $this->parseList($declareStatement, ParseContext::DeclareStatementElements);
-            $declareStatement->enddeclareKeyword = $this->eat(TokenKind::EndDeclareKeyword);
+            $declareStatement->enddeclareKeyword = $this->eat1(TokenKind::EndDeclareKeyword);
             $declareStatement->semicolon = $this->eatSemicolonOrAbortStatement();
         } else {
             $declareStatement->statements = $this->parseStatement($declareStatement);
@@ -1977,8 +2010,8 @@ class Parser {
     private function parseDeclareDirective($parentNode) {
         $declareDirective = new DeclareDirective();
         $declareDirective->parent = $parentNode;
-        $declareDirective->name = $this->eat(TokenKind::Name);
-        $declareDirective->equals = $this->eat(TokenKind::EqualsToken);
+        $declareDirective->name = $this->eat1(TokenKind::Name);
+        $declareDirective->equals = $this->eat1(TokenKind::EqualsToken);
         $declareDirective->literal =
             $this->eat(
                 TokenKind::FloatingLiteralToken,
@@ -2007,7 +2040,7 @@ class Parser {
             $variable->parent = $parentNode;
 
             if ($token->kind === TokenKind::DollarToken) {
-                $variable->dollar = $this->eat(TokenKind::DollarToken);
+                $variable->dollar = $this->eat1(TokenKind::DollarToken);
                 $token = $this->getCurrentToken();
 
                 $variable->name =
@@ -2053,7 +2086,7 @@ class Parser {
     private function parseEchoExpression($parentNode) {
         $echoExpression = new EchoExpression();
         $echoExpression->parent = $parentNode;
-        $echoExpression->echoKeyword = $this->eat(TokenKind::EchoKeyword);
+        $echoExpression->echoKeyword = $this->eat1(TokenKind::EchoKeyword);
         $echoExpression->expressions =
             $this->parseExpressionList($echoExpression);
 
@@ -2063,12 +2096,12 @@ class Parser {
     private function parseListIntrinsicExpression($parentNode) {
         $listExpression = new ListIntrinsicExpression();
         $listExpression->parent = $parentNode;
-        $listExpression->listKeyword = $this->eat(TokenKind::ListKeyword);
-        $listExpression->openParen = $this->eat(TokenKind::OpenParenToken);
+        $listExpression->listKeyword = $this->eat1(TokenKind::ListKeyword);
+        $listExpression->openParen = $this->eat1(TokenKind::OpenParenToken);
         // TODO - parse loosely as ArrayElementList, and validate parse tree later
         $listExpression->listElements =
             $this->parseArrayElementList($listExpression, DelimitedList\ListExpressionList::class);
-        $listExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $listExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         return $listExpression;
     }
@@ -2093,14 +2126,14 @@ class Parser {
             $arrayElement->parent = $parentNode;
 
             if ($this->checkToken(TokenKind::AmpersandToken)) {
-                $arrayElement->byRef = $this->eat(TokenKind::AmpersandToken);
+                $arrayElement->byRef = $this->eat1(TokenKind::AmpersandToken);
                 $arrayElement->elementValue = $this->parseExpression($arrayElement);
             } else {
                 $expression = $this->parseExpression($arrayElement);
                 if ($this->checkToken(TokenKind::DoubleArrowToken)) {
                     $arrayElement->elementKey = $expression;
-                    $arrayElement->arrowToken = $this->eat(TokenKind::DoubleArrowToken);
-                    $arrayElement->byRef = $this->eatOptional(TokenKind::AmpersandToken); // TODO not okay for list expressions
+                    $arrayElement->arrowToken = $this->eat1(TokenKind::DoubleArrowToken);
+                    $arrayElement->byRef = $this->eatOptional1(TokenKind::AmpersandToken); // TODO not okay for list expressions
                     $arrayElement->elementValue = $this->parseExpression($arrayElement);
                 } else {
                     $arrayElement->elementValue = $expression;
@@ -2125,10 +2158,10 @@ class Parser {
         $unsetExpression = new UnsetIntrinsicExpression();
         $unsetExpression->parent = $parentNode;
 
-        $unsetExpression->unsetKeyword = $this->eat(TokenKind::UnsetKeyword);
-        $unsetExpression->openParen = $this->eat(TokenKind::OpenParenToken);
+        $unsetExpression->unsetKeyword = $this->eat1(TokenKind::UnsetKeyword);
+        $unsetExpression->openParen = $this->eat1(TokenKind::OpenParenToken);
         $unsetExpression->expressions = $this->parseExpressionList($unsetExpression);
-        $unsetExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $unsetExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         return $unsetExpression;
     }
@@ -2137,17 +2170,17 @@ class Parser {
         $arrayExpression = new ArrayCreationExpression();
         $arrayExpression->parent = $parentNode;
 
-        $arrayExpression->arrayKeyword = $this->eatOptional(TokenKind::ArrayKeyword);
+        $arrayExpression->arrayKeyword = $this->eatOptional1(TokenKind::ArrayKeyword);
 
         $arrayExpression->openParenOrBracket = $arrayExpression->arrayKeyword !== null
-            ? $this->eat(TokenKind::OpenParenToken)
-            : $this->eat(TokenKind::OpenBracketToken);
+            ? $this->eat1(TokenKind::OpenParenToken)
+            : $this->eat1(TokenKind::OpenBracketToken);
 
         $arrayExpression->arrayElements = $this->parseArrayElementList($arrayExpression, DelimitedList\ArrayElementList::class);
 
         $arrayExpression->closeParenOrBracket = $arrayExpression->arrayKeyword !== null
-            ? $this->eat(TokenKind::CloseParenToken)
-            : $this->eat(TokenKind::CloseBracketToken);
+            ? $this->eat1(TokenKind::CloseParenToken)
+            : $this->eat1(TokenKind::CloseBracketToken);
 
         return $arrayExpression;
     }
@@ -2167,10 +2200,10 @@ class Parser {
         $emptyExpression = new EmptyIntrinsicExpression();
         $emptyExpression->parent = $parentNode;
 
-        $emptyExpression->emptyKeyword = $this->eat(TokenKind::EmptyKeyword);
-        $emptyExpression->openParen = $this->eat(TokenKind::OpenParenToken);
+        $emptyExpression->emptyKeyword = $this->eat1(TokenKind::EmptyKeyword);
+        $emptyExpression->openParen = $this->eat1(TokenKind::OpenParenToken);
         $emptyExpression->expression = $this->parseExpression($emptyExpression);
-        $emptyExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $emptyExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         return $emptyExpression;
     }
@@ -2179,10 +2212,10 @@ class Parser {
         $evalExpression = new EvalIntrinsicExpression();
         $evalExpression->parent = $parentNode;
 
-        $evalExpression->evalKeyword = $this->eat(TokenKind::EvalKeyword);
-        $evalExpression->openParen = $this->eat(TokenKind::OpenParenToken);
+        $evalExpression->evalKeyword = $this->eat1(TokenKind::EvalKeyword);
+        $evalExpression->openParen = $this->eat1(TokenKind::OpenParenToken);
         $evalExpression->expression = $this->parseExpression($evalExpression);
-        $evalExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $evalExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         return $evalExpression;
     }
@@ -2191,9 +2224,9 @@ class Parser {
         $parenthesizedExpression = new ParenthesizedExpression();
         $parenthesizedExpression->parent = $parentNode;
 
-        $parenthesizedExpression->openParen = $this->eat(TokenKind::OpenParenToken);
+        $parenthesizedExpression->openParen = $this->eat1(TokenKind::OpenParenToken);
         $parenthesizedExpression->expression = $this->parseExpression($parenthesizedExpression);
-        $parenthesizedExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $parenthesizedExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         return $parenthesizedExpression;
     }
@@ -2203,12 +2236,12 @@ class Parser {
         $exitExpression->parent = $parentNode;
 
         $exitExpression->exitOrDieKeyword = $this->eat(TokenKind::ExitKeyword, TokenKind::DieKeyword);
-        $exitExpression->openParen = $this->eatOptional(TokenKind::OpenParenToken);
+        $exitExpression->openParen = $this->eatOptional1(TokenKind::OpenParenToken);
         if ($exitExpression->openParen !== null) {
             if ($this->isExpressionStart($this->getCurrentToken())) {
                 $exitExpression->expression = $this->parseExpression($exitExpression);
             }
-            $exitExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+            $exitExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
         }
 
         return $exitExpression;
@@ -2218,7 +2251,7 @@ class Parser {
         $printExpression = new PrintIntrinsicExpression();
         $printExpression->parent = $parentNode;
 
-        $printExpression->printKeyword = $this->eat(TokenKind::PrintKeyword);
+        $printExpression->printKeyword = $this->eat1(TokenKind::PrintKeyword);
         $printExpression->expression = $this->parseExpression($printExpression);
 
         return $printExpression;
@@ -2228,10 +2261,10 @@ class Parser {
         $issetExpression = new IssetIntrinsicExpression();
         $issetExpression->parent = $parentNode;
 
-        $issetExpression->issetKeyword = $this->eat(TokenKind::IsSetKeyword);
-        $issetExpression->openParen = $this->eat(TokenKind::OpenParenToken);
+        $issetExpression->issetKeyword = $this->eat1(TokenKind::IsSetKeyword);
+        $issetExpression->openParen = $this->eat1(TokenKind::OpenParenToken);
         $issetExpression->expressions = $this->parseExpressionList($issetExpression);
-        $issetExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $issetExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         return $issetExpression;
     }
@@ -2250,7 +2283,7 @@ class Parser {
         $errorControlExpression = new ErrorControlExpression();
         $errorControlExpression->parent = $parentNode;
 
-        $errorControlExpression->operator = $this->eat(TokenKind::AtSymbolToken);
+        $errorControlExpression->operator = $this->eat1(TokenKind::AtSymbolToken);
         $errorControlExpression->operand = $this->parseUnaryExpressionOrHigher($errorControlExpression);
 
         return $errorControlExpression;
@@ -2365,8 +2398,8 @@ class Parser {
         return function ($parentNode) {
             $argumentExpression = new ArgumentExpression();
             $argumentExpression->parent = $parentNode;
-            $argumentExpression->byRefToken = $this->eatOptional(TokenKind::AmpersandToken);
-            $argumentExpression->dotDotDotToken = $this->eatOptional(TokenKind::DotDotDotToken);
+            $argumentExpression->byRefToken = $this->eatOptional1(TokenKind::AmpersandToken);
+            $argumentExpression->dotDotDotToken = $this->eatOptional1(TokenKind::DotDotDotToken);
             $argumentExpression->expression = $this->parseExpression($argumentExpression);
             return $argumentExpression;
         };
@@ -2377,10 +2410,10 @@ class Parser {
         $callExpression->parent = $expression->parent;
         $expression->parent = $callExpression;
         $callExpression->callableExpression = $expression;
-        $callExpression->openParen = $this->eat(TokenKind::OpenParenToken);
+        $callExpression->openParen = $this->eat1(TokenKind::OpenParenToken);
         $callExpression->argumentExpressionList =
             $this->parseArgumentExpressionList($callExpression);
-        $callExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $callExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
         return $callExpression;
     }
 
@@ -2398,9 +2431,9 @@ class Parser {
         $bracedExpression = new BracedExpression();
         $bracedExpression->parent = $parentNode;
 
-        $bracedExpression->openBrace = $this->eat(TokenKind::OpenBraceToken);
+        $bracedExpression->openBrace = $this->eat1(TokenKind::OpenBraceToken);
         $bracedExpression->expression = $this->parseExpression($bracedExpression);
-        $bracedExpression->closeBrace = $this->eat(TokenKind::CloseBraceToken);
+        $bracedExpression->closeBrace = $this->eat1(TokenKind::CloseBraceToken);
 
         return $bracedExpression;
     }
@@ -2417,9 +2450,9 @@ class Parser {
             : null; // TODO error if used in a getter
 
         if ($subscriptExpression->openBracketOrBrace->kind === TokenKind::OpenBraceToken) {
-            $subscriptExpression->closeBracketOrBrace = $this->eat(TokenKind::CloseBraceToken);
+            $subscriptExpression->closeBracketOrBrace = $this->eat1(TokenKind::CloseBraceToken);
         } else {
-            $subscriptExpression->closeBracketOrBrace = $this->eat(TokenKind::CloseBracketToken);
+            $subscriptExpression->closeBracketOrBrace = $this->eat1(TokenKind::CloseBracketToken);
         }
 
         return $subscriptExpression;
@@ -2431,7 +2464,7 @@ class Parser {
         $expression->parent = $memberAccessExpression;
 
         $memberAccessExpression->dereferencableExpression = $expression;
-        $memberAccessExpression->arrowToken = $this->eat(TokenKind::ArrowToken);
+        $memberAccessExpression->arrowToken = $this->eat1(TokenKind::ArrowToken);
         $memberAccessExpression->memberName = $this->parseMemberName($memberAccessExpression);
 
         return $memberAccessExpression;
@@ -2443,7 +2476,7 @@ class Parser {
         $expression->parent = $scopedPropertyAccessExpression;
 
         $scopedPropertyAccessExpression->scopeResolutionQualifier = $expression; // TODO ensure always a Node
-        $scopedPropertyAccessExpression->doubleColon = $this->eat(TokenKind::ColonColonToken);
+        $scopedPropertyAccessExpression->doubleColon = $this->eat1(TokenKind::ColonColonToken);
         $scopedPropertyAccessExpression->memberName = $this->parseMemberName($scopedPropertyAccessExpression);
 
         return $scopedPropertyAccessExpression;
@@ -2454,20 +2487,20 @@ class Parser {
     private function parseObjectCreationExpression($parentNode) {
         $objectCreationExpression = new ObjectCreationExpression();
         $objectCreationExpression->parent = $parentNode;
-        $objectCreationExpression->newKeword = $this->eat(TokenKind::NewKeyword);
+        $objectCreationExpression->newKeword = $this->eat1(TokenKind::NewKeyword);
         // TODO - add tests for this scenario
         $this->isParsingObjectCreationExpression = true;
         $objectCreationExpression->classTypeDesignator =
-            $this->eatOptional(TokenKind::ClassKeyword) ??
-            $this->eatOptional(TokenKind::StaticKeyword) ??
+            $this->eatOptional1(TokenKind::ClassKeyword) ??
+            $this->eatOptional1(TokenKind::StaticKeyword) ??
             $this->parseExpression($objectCreationExpression);
 
         $this->isParsingObjectCreationExpression = false;
 
-        $objectCreationExpression->openParen = $this->eatOptional(TokenKind::OpenParenToken);
+        $objectCreationExpression->openParen = $this->eatOptional1(TokenKind::OpenParenToken);
         if ($objectCreationExpression->openParen !== null) {
             $objectCreationExpression->argumentExpressionList = $this->parseArgumentExpressionList($objectCreationExpression);
-            $objectCreationExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+            $objectCreationExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
         }
 
         $objectCreationExpression->classBaseClause = $this->parseClassBaseClause($objectCreationExpression);
@@ -2497,7 +2530,7 @@ class Parser {
         $ternaryExpression->condition = $leftOperand;
         $ternaryExpression->questionToken = $questionToken;
         $ternaryExpression->ifExpression = $this->isExpressionStart($this->getCurrentToken()) ? $this->parseExpression($ternaryExpression) : null;
-        $ternaryExpression->colonToken = $this->eat(TokenKind::ColonToken);
+        $ternaryExpression->colonToken = $this->eat1(TokenKind::ColonToken);
         $ternaryExpression->elseExpression = $this->parseBinaryExpressionOrHigher(9, $ternaryExpression);
         $leftOperand = $ternaryExpression;
         return $leftOperand;
@@ -2506,7 +2539,7 @@ class Parser {
     private function parseClassInterfaceClause($parentNode) {
         $classInterfaceClause = new ClassInterfaceClause();
         $classInterfaceClause->parent = $parentNode;
-        $classInterfaceClause->implementsKeyword = $this->eatOptional(TokenKind::ImplementsKeyword);
+        $classInterfaceClause->implementsKeyword = $this->eatOptional1(TokenKind::ImplementsKeyword);
 
         if ($classInterfaceClause->implementsKeyword === null) {
             return null;
@@ -2521,7 +2554,7 @@ class Parser {
         $classBaseClause = new ClassBaseClause();
         $classBaseClause->parent = $parentNode;
 
-        $classBaseClause->extendsKeyword = $this->eatOptional(TokenKind::ExtendsKeyword);
+        $classBaseClause->extendsKeyword = $this->eatOptional1(TokenKind::ExtendsKeyword);
         if ($classBaseClause->extendsKeyword === null) {
             return null;
         }
@@ -2535,9 +2568,9 @@ class Parser {
         $classConstDeclaration->parent = $parentNode;
 
         $classConstDeclaration->modifiers = $modifiers;
-        $classConstDeclaration->constKeyword = $this->eat(TokenKind::ConstKeyword);
+        $classConstDeclaration->constKeyword = $this->eat1(TokenKind::ConstKeyword);
         $classConstDeclaration->constElements = $this->parseConstElements($classConstDeclaration);
-        $classConstDeclaration->semicolon = $this->eat(TokenKind::SemicolonToken);
+        $classConstDeclaration->semicolon = $this->eat1(TokenKind::SemicolonToken);
 
         return $classConstDeclaration;
     }
@@ -2548,7 +2581,7 @@ class Parser {
 
         $propertyDeclaration->modifiers = $modifiers;
         $propertyDeclaration->propertyElements = $this->parseExpressionList($propertyDeclaration);
-        $propertyDeclaration->semicolon = $this->eat(TokenKind::SemicolonToken);
+        $propertyDeclaration->semicolon = $this->eat1(TokenKind::SemicolonToken);
 
         return $propertyDeclaration;
     }
@@ -2565,8 +2598,8 @@ class Parser {
     private function parseInterfaceDeclaration($parentNode) {
         $interfaceDeclaration = new InterfaceDeclaration(); // TODO verify not nested
         $interfaceDeclaration->parent = $parentNode;
-        $interfaceDeclaration->interfaceKeyword = $this->eat(TokenKind::InterfaceKeyword);
-        $interfaceDeclaration->name = $this->eat(TokenKind::Name);
+        $interfaceDeclaration->interfaceKeyword = $this->eat1(TokenKind::InterfaceKeyword);
+        $interfaceDeclaration->name = $this->eat1(TokenKind::Name);
         $interfaceDeclaration->interfaceBaseClause = $this->parseInterfaceBaseClause($interfaceDeclaration);
         $interfaceDeclaration->interfaceMembers = $this->parseInterfaceMembers($interfaceDeclaration);
         return $interfaceDeclaration;
@@ -2574,9 +2607,9 @@ class Parser {
 
     private function parseInterfaceMembers($parentNode) : Node {
         $interfaceMembers = new InterfaceMembers();
-        $interfaceMembers->openBrace = $this->eat(TokenKind::OpenBraceToken);
+        $interfaceMembers->openBrace = $this->eat1(TokenKind::OpenBraceToken);
         $interfaceMembers->interfaceMemberDeclarations = $this->parseList($interfaceMembers, ParseContext::InterfaceMembers);
-        $interfaceMembers->closeBrace = $this->eat(TokenKind::CloseBraceToken);
+        $interfaceMembers->closeBrace = $this->eat1(TokenKind::CloseBraceToken);
         $interfaceMembers->parent = $parentNode;
         return $interfaceMembers;
     }
@@ -2628,7 +2661,7 @@ class Parser {
         $interfaceBaseClause = new InterfaceBaseClause();
         $interfaceBaseClause->parent = $parentNode;
 
-        $interfaceBaseClause->extendsKeyword = $this->eatOptional(TokenKind::ExtendsKeyword);
+        $interfaceBaseClause->extendsKeyword = $this->eatOptional1(TokenKind::ExtendsKeyword);
         if (isset($interfaceBaseClause->extendsKeyword)) {
             $interfaceBaseClause->interfaceNameList = $this->parseQualifiedNameList($interfaceBaseClause);
         } else {
@@ -2642,7 +2675,7 @@ class Parser {
         $namespaceDefinition = new NamespaceDefinition();
         $namespaceDefinition->parent = $parentNode;
 
-        $namespaceDefinition->namespaceKeyword = $this->eat(TokenKind::NamespaceKeyword);
+        $namespaceDefinition->namespaceKeyword = $this->eat1(TokenKind::NamespaceKeyword);
 
         if (!$this->checkToken(TokenKind::NamespaceKeyword)) {
             $namespaceDefinition->name = $this->parseQualifiedName($namespaceDefinition); // TODO only optional with compound statement block
@@ -2658,7 +2691,7 @@ class Parser {
     private function parseNamespaceUseDeclaration($parentNode) {
         $namespaceUseDeclaration = new NamespaceUseDeclaration();
         $namespaceUseDeclaration->parent = $parentNode;
-        $namespaceUseDeclaration->useKeyword = $this->eat(TokenKind::UseKeyword);
+        $namespaceUseDeclaration->useKeyword = $this->eat1(TokenKind::UseKeyword);
         $namespaceUseDeclaration->functionOrConst = $this->eatOptional(TokenKind::FunctionKeyword, TokenKind::ConstKeyword);
         $namespaceUseDeclaration->useClauses = $this->parseNamespaceUseClauseList($namespaceUseDeclaration);
         $namespaceUseDeclaration->semicolon = $this->eatSemicolonOrAbortStatement();
@@ -2680,9 +2713,9 @@ class Parser {
                     $namespaceUseClause->namespaceAliasingClause = $this->parseNamespaceAliasingClause($namespaceUseClause);
                 }
                 elseif ($this->checkToken(TokenKind::OpenBraceToken)) {
-                    $namespaceUseClause->openBrace = $this->eat(TokenKind::OpenBraceToken);
+                    $namespaceUseClause->openBrace = $this->eat1(TokenKind::OpenBraceToken);
                     $namespaceUseClause->groupClauses = $this->parseNamespaceUseGroupClauseList($namespaceUseClause);
-                    $namespaceUseClause->closeBrace = $this->eat(TokenKind::CloseBraceToken);
+                    $namespaceUseClause->closeBrace = $this->eat1(TokenKind::CloseBraceToken);
                 }
 
                 return $namespaceUseClause;
@@ -2717,8 +2750,8 @@ class Parser {
     private function parseNamespaceAliasingClause($parentNode) {
         $namespaceAliasingClause = new NamespaceAliasingClause();
         $namespaceAliasingClause->parent = $parentNode;
-        $namespaceAliasingClause->asKeyword = $this->eat(TokenKind::AsKeyword);
-        $namespaceAliasingClause->name = $this->eat(TokenKind::Name);
+        $namespaceAliasingClause->asKeyword = $this->eat1(TokenKind::AsKeyword);
+        $namespaceAliasingClause->name = $this->eat1(TokenKind::Name);
         return $namespaceAliasingClause;
     }
 
@@ -2726,8 +2759,8 @@ class Parser {
         $traitDeclaration = new TraitDeclaration();
         $traitDeclaration->parent = $parentNode;
 
-        $traitDeclaration->traitKeyword = $this->eat(TokenKind::TraitKeyword);
-        $traitDeclaration->name = $this->eat(TokenKind::Name);
+        $traitDeclaration->traitKeyword = $this->eat1(TokenKind::TraitKeyword);
+        $traitDeclaration->name = $this->eat1(TokenKind::Name);
 
         $traitDeclaration->traitMembers = $this->parseTraitMembers($traitDeclaration);
 
@@ -2738,11 +2771,11 @@ class Parser {
         $traitMembers = new TraitMembers();
         $traitMembers->parent = $parentNode;
 
-        $traitMembers->openBrace = $this->eat(TokenKind::OpenBraceToken);
+        $traitMembers->openBrace = $this->eat1(TokenKind::OpenBraceToken);
 
         $traitMembers->traitMemberDeclarations = $this->parseList($traitMembers, ParseContext::TraitMembers);
 
-        $traitMembers->closeBrace = $this->eat(TokenKind::CloseBraceToken);
+        $traitMembers->closeBrace = $this->eat1(TokenKind::CloseBraceToken);
 
         return $traitMembers;
     }
@@ -2799,13 +2832,13 @@ class Parser {
         $traitUseClause = new TraitUseClause();
         $traitUseClause->parent = $parentNode;
 
-        $traitUseClause->useKeyword = $this->eat(TokenKind::UseKeyword);
+        $traitUseClause->useKeyword = $this->eat1(TokenKind::UseKeyword);
         $traitUseClause->traitNameList = $this->parseQualifiedNameList($traitUseClause);
 
         $traitUseClause->semicolonOrOpenBrace = $this->eat(TokenKind::OpenBraceToken, TokenKind::SemicolonToken);
         if ($traitUseClause->semicolonOrOpenBrace->kind === TokenKind::OpenBraceToken) {
             $traitUseClause->traitSelectAndAliasClauses = $this->parseTraitSelectAndAliasClauseList($traitUseClause);
-            $traitUseClause->closeBrace = $this->eat(TokenKind::CloseBraceToken);
+            $traitUseClause->closeBrace = $this->eat1(TokenKind::CloseBraceToken);
         }
 
         return $traitUseClause;
@@ -2851,7 +2884,7 @@ class Parser {
         $globalDeclaration = new GlobalDeclaration();
         $globalDeclaration->parent = $parentNode;
 
-        $globalDeclaration->globalKeyword = $this->eat(TokenKind::GlobalKeyword);
+        $globalDeclaration->globalKeyword = $this->eat1(TokenKind::GlobalKeyword);
         $globalDeclaration->variableNameList = $this->parseDelimitedList(
             DelimitedList\VariableNameList::class,
             TokenKind::CommaToken,
@@ -2869,7 +2902,7 @@ class Parser {
         $functionStaticDeclaration = new FunctionStaticDeclaration();
         $functionStaticDeclaration->parent = $parentNode;
 
-        $functionStaticDeclaration->staticKeyword = $this->eat(TokenKind::StaticKeyword);
+        $functionStaticDeclaration->staticKeyword = $this->eat1(TokenKind::StaticKeyword);
         $functionStaticDeclaration->staticVariableNameList = $this->parseDelimitedList(
             DelimitedList\StaticVariableNameList::class,
             TokenKind::CommaToken,
@@ -2894,8 +2927,8 @@ class Parser {
         return function ($parentNode) {
             $staticVariableDeclaration = new StaticVariableDeclaration();
             $staticVariableDeclaration->parent = $parentNode;
-            $staticVariableDeclaration->variableName = $this->eat(TokenKind::VariableName);
-            $staticVariableDeclaration->equalsToken = $this->eatOptional(TokenKind::EqualsToken);
+            $staticVariableDeclaration->variableName = $this->eat1(TokenKind::VariableName);
+            $staticVariableDeclaration->equalsToken = $this->eatOptional1(TokenKind::EqualsToken);
             if ($staticVariableDeclaration->equalsToken !== null) {
                 // TODO add post-parse rule that checks for invalid assignments
                 $staticVariableDeclaration->assignment = $this->parseExpression($staticVariableDeclaration);
@@ -2908,7 +2941,7 @@ class Parser {
         $constDeclaration = new ConstDeclaration();
         $constDeclaration->parent = $parentNode;
 
-        $constDeclaration->constKeyword = $this->eat(TokenKind::ConstKeyword);
+        $constDeclaration->constKeyword = $this->eat1(TokenKind::ConstKeyword);
         $constDeclaration->constElements = $this->parseConstElements($constDeclaration);
         $constDeclaration->semicolon = $this->eatSemicolonOrAbortStatement();
 
@@ -2934,7 +2967,7 @@ class Parser {
             $constElement->name = $this->getCurrentToken();
             $this->advanceToken();
             $constElement->name->kind = TokenKind::Name; // to support keyword names
-            $constElement->equalsToken = $this->eat(TokenKind::EqualsToken);
+            $constElement->equalsToken = $this->eat1(TokenKind::EqualsToken);
             // TODO add post-parse rule that checks for invalid assignments
             $constElement->assignment = $this->parseExpression($constElement);
             return $constElement;
@@ -2963,7 +2996,7 @@ class Parser {
         $castExpression = new CastExpression();
         $castExpression->parent = $parentNode;
 
-        $castExpression->openParen = $this->eat(TokenKind::OpenParenToken);
+        $castExpression->openParen = $this->eat1(TokenKind::OpenParenToken);
         $castExpression->castType = $this->eat(
             TokenKind::ArrayKeyword,
             TokenKind::BinaryReservedWord,
@@ -2978,7 +3011,7 @@ class Parser {
             TokenKind::StringReservedWord,
             TokenKind::UnsetKeyword
         );
-        $castExpression->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $castExpression->closeParen = $this->eat1(TokenKind::CloseParenToken);
         $castExpression->operand = $this->parseUnaryExpressionOrHigher($castExpression);
 
         return $castExpression;
@@ -2988,7 +3021,7 @@ class Parser {
         $anonymousFunctionCreationExpression = new AnonymousFunctionCreationExpression();
         $anonymousFunctionCreationExpression->parent = $parentNode;
 
-        $anonymousFunctionCreationExpression->staticModifier = $this->eatOptional(TokenKind::StaticKeyword);
+        $anonymousFunctionCreationExpression->staticModifier = $this->eatOptional1(TokenKind::StaticKeyword);
         $this->parseFunctionType($anonymousFunctionCreationExpression, false, true);
 
         return $anonymousFunctionCreationExpression;
@@ -2998,11 +3031,11 @@ class Parser {
         $anonymousFunctionUseClause = new AnonymousFunctionUseClause();
         $anonymousFunctionUseClause->parent = $parentNode;
 
-        $anonymousFunctionUseClause->useKeyword = $this->eatOptional(TokenKind::UseKeyword);
+        $anonymousFunctionUseClause->useKeyword = $this->eatOptional1(TokenKind::UseKeyword);
         if ($anonymousFunctionUseClause->useKeyword === null) {
             return null;
         }
-        $anonymousFunctionUseClause->openParen = $this->eat(TokenKind::OpenParenToken);
+        $anonymousFunctionUseClause->openParen = $this->eat1(TokenKind::OpenParenToken);
         $anonymousFunctionUseClause->useVariableNameList = $this->parseDelimitedList(
             DelimitedList\UseVariableNameList::class,
             TokenKind::CommaToken,
@@ -3012,13 +3045,13 @@ class Parser {
             function ($parentNode) {
                 $useVariableName = new UseVariableName();
                 $useVariableName->parent = $parentNode;
-                $useVariableName->byRef = $this->eatOptional(TokenKind::AmpersandToken);
-                $useVariableName->variableName = $this->eat(TokenKind::VariableName);
+                $useVariableName->byRef = $this->eatOptional1(TokenKind::AmpersandToken);
+                $useVariableName->variableName = $this->eat1(TokenKind::VariableName);
                 return $useVariableName;
             },
             $anonymousFunctionUseClause
         );
-        $anonymousFunctionUseClause->closeParen = $this->eat(TokenKind::CloseParenToken);
+        $anonymousFunctionUseClause->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         return $anonymousFunctionUseClause;
     }
@@ -3027,7 +3060,7 @@ class Parser {
         $cloneExpression = new CloneExpression();
         $cloneExpression->parent = $parentNode;
 
-        $cloneExpression->cloneKeyword = $this->eat(TokenKind::CloneKeyword);
+        $cloneExpression->cloneKeyword = $this->eat1(TokenKind::CloneKeyword);
         $cloneExpression->expression = $this->parseUnaryExpressionOrHigher($cloneExpression);
 
         return $cloneExpression;
@@ -3035,7 +3068,7 @@ class Parser {
 
     private function eatSemicolonOrAbortStatement() {
         if ($this->getCurrentToken()->kind !== TokenKind::ScriptSectionEndTag) {
-            return $this->eat(TokenKind::SemicolonToken);
+            return $this->eat1(TokenKind::SemicolonToken);
         }
         return null;
     }
@@ -3043,9 +3076,9 @@ class Parser {
     private function parseInlineHtml($parentNode) {
         $inlineHtml = new InlineHtml();
         $inlineHtml->parent = $parentNode;
-        $inlineHtml->scriptSectionEndTag = $this->eatOptional(TokenKind::ScriptSectionEndTag);
-        $inlineHtml->text = $this->eatOptional(TokenKind::InlineHtml);
-        $inlineHtml->scriptSectionStartTag = $this->eatOptional(TokenKind::ScriptSectionStartTag);
+        $inlineHtml->scriptSectionEndTag = $this->eatOptional1(TokenKind::ScriptSectionEndTag);
+        $inlineHtml->text = $this->eatOptional1(TokenKind::InlineHtml);
+        $inlineHtml->scriptSectionStartTag = $this->eatOptional1(TokenKind::ScriptSectionStartTag);
 
         return $inlineHtml;
     }


### PR DESCRIPTION
and a faster version of eatOptional().

eat() is called frequently when converting lexed tokens to values,
and often with a single token type. Varargs and array counting would
slow that down.

validatiion/ParserPerformance sped up from 0.581 to 0.574 seconds (1%).
(Added a loop to run on 100 files 10 times, divided by 10, took best times)

eatSingle might be a better name, but I'm not sure if this would get expanded to eatArray(array $x), eat2($kind1, $kind2), etc. It's private, so it can easily be changed.