### PR TITLE
Optimize getDiagnostics for speed

### DIFF
--- a/experiments/BenchGetDiagnostics.php
+++ b/experiments/BenchGetDiagnostics.php
@@ -1,0 +1,26 @@
+<?php
+// Autoload required classes
+require dirname(__DIR__) . "/vendor/autoload.php";
+
+use Microsoft\PhpParser\{DiagnosticsProvider, Node, Parser, PositionUtilities};
+
+
+const ITERATIONS = 100;
+// Return and print an AST from string contents
+$main = function() {
+    // Instantiate new parser instance
+    // TODO: Multiple source files to be realistic.
+    $parser = new Parser();
+    $t0 = microtime(true);
+    $astNode = $parser->parseSourceFile(file_get_contents(__DIR__ . '/../src/Parser.php'));
+    $t1 = microtime(true);
+    for ($i = 0; $i < ITERATIONS; $i++) {
+        $diagnostics = DiagnosticsProvider::getDiagnostics($astNode);
+    }
+    $t2 = microtime(true);
+    printf("Average time to generate diagnostics: %.6f\n", ($t2 - $t1) / ITERATIONS);
+    printf("time to parse: %.6f\n", ($t1 - $t0));
+    global $__counts;
+    var_export($__counts);
+};
+$main();

--- a/src/DiagnosticsProvider.php
+++ b/src/DiagnosticsProvider.php
@@ -10,6 +10,9 @@ use Microsoft\PhpParser\Node;
 
 class DiagnosticsProvider {
 
+    /**
+     * @var string[] maps the token kind to the corresponding name
+     */
     private static $tokenKindToText;
 
     /**
@@ -17,16 +20,14 @@ class DiagnosticsProvider {
      * @return string
      */
     public static function getTextForTokenKind($kind) {
-        if (!isset(self::$tokenKindToText)) {
-            self::initTokenKindToText();
-        }
         return self::$tokenKindToText[$kind];
     }
 
     /**
-     * @return string[]
+     * This is called when this class is loaded, at the bottom of this file.
+     * @return void
      */
-    private static function initTokenKindToText() {
+    public static function initTokenKindToText() {
         self::$tokenKindToText = \array_flip(\array_merge(
             TokenStringMaps::OPERATORS_AND_PUNCTUATORS,
             TokenStringMaps::KEYWORDS,
@@ -58,9 +59,6 @@ class DiagnosticsProvider {
      * @return Diagnostic|null
      */
     private static function checkDiagnosticForUnexpectedToken($token) {
-        if (!isset(self::$tokenKindToText)) {
-            self::initTokenKindToText();
-        }
         if ($token instanceof SkippedToken) {
             // TODO - consider also attaching parse context information to skipped tokens
             // this would allow us to provide more helpful error messages that inform users what to do
@@ -107,3 +105,5 @@ class DiagnosticsProvider {
         return $diagnostics;
     }
 }
+
+DiagnosticsProvider::initTokenKindToText();

--- a/src/Node.php
+++ b/src/Node.php
@@ -172,13 +172,14 @@ abstract class Node implements \JsonSerializable {
 
     /**
      * Iterate over all descendant Nodes and Tokens, calling $callback.
-     * This can often be faster than getDescendantNodesAndTokens if you just need to call something and don't be a generator.
+     * This can often be faster than getDescendantNodesAndTokens
+     * if you just need to call something and don't need a generator.
      *
      * @param callable $callback a callback that accepts Node|Token
      * @param callable|null $shouldDescendIntoChildrenFn
      * @return void
      */
-    public function walkDescendantNodesAndTokens(\Closure $callback, callable $shouldDescendIntoChildrenFn = null) {
+    public function walkDescendantNodesAndTokens(callable $callback, callable $shouldDescendIntoChildrenFn = null) {
         // TODO - write unit tests to prove invariants
         // (concatenating all descendant Tokens should produce document, concatenating all Nodes should produce document)
         foreach (static::CHILD_NAMES as $name) {

--- a/src/Node.php
+++ b/src/Node.php
@@ -158,13 +158,50 @@ abstract class Node implements \JsonSerializable {
         // TODO - write unit tests to prove invariants
         // (concatenating all descendant Tokens should produce document, concatenating all Nodes should produce document)
         foreach ($this->getChildNodesAndTokens() as $child) {
+            // Check possible types of $child, most frequent first
             if ($child instanceof Node) {
                 yield $child;
-                if ($shouldDescendIntoChildrenFn == null || $shouldDescendIntoChildrenFn($child)) {
-                    yield from $child->getDescendantNodesAndTokens($shouldDescendIntoChildrenFn);
+                if ($shouldDescendIntoChildrenFn === null || $shouldDescendIntoChildrenFn($child)) {
+                   yield from $child->getDescendantNodesAndTokens($shouldDescendIntoChildrenFn);
                 }
             } elseif ($child instanceof Token) {
                 yield $child;
+            }
+        }
+    }
+
+    /**
+     * Iterate over all descendant Nodes and Tokens, calling $callback.
+     * This can often be faster than getDescendantNodesAndTokens if you just need to call something and don't be a generator.
+     *
+     * @param callable $callback a callback that accepts Node|Token
+     * @param callable|null $shouldDescendIntoChildrenFn
+     * @return void
+     */
+    public function walkDescendantNodesAndTokens(\Closure $callback, callable $shouldDescendIntoChildrenFn = null) {
+        // TODO - write unit tests to prove invariants
+        // (concatenating all descendant Tokens should produce document, concatenating all Nodes should produce document)
+        foreach (static::CHILD_NAMES as $name) {
+            $child = $this->$name;
+            // Check possible types of $child, most frequent first
+            if ($child instanceof Token) {
+                $callback($child);
+            } elseif ($child instanceof Node) {
+                $callback($child);
+                if ($shouldDescendIntoChildrenFn === null || $shouldDescendIntoChildrenFn($child)) {
+                   $child->walkDescendantNodesAndTokens($callback, $shouldDescendIntoChildrenFn);
+                }
+            } elseif (\is_array($child)) {
+                foreach ($child as $childElement) {
+                    if ($childElement instanceof Token) {
+                        $callback($childElement);
+                    } elseif ($childElement instanceof Node) {
+                        $callback($childElement);
+                        if ($shouldDescendIntoChildrenFn === null || $shouldDescendIntoChildrenFn($childElement)) {
+                           $childElement->walkDescendantNodesAndTokens($callback, $shouldDescendIntoChildrenFn);
+                        }
+                    }
+                }
             }
         }
     }
@@ -638,5 +675,14 @@ abstract class Node implements \JsonSerializable {
             return array($namespaceImportTable, $functionImportTable, $constImportTable);
         }
         return array($namespaceImportTable, $functionImportTable, $constImportTable);
+    }
+
+    /**
+     * This is overridden in subclasses
+     * @return Diagnostic|null - Callers should use DiagnosticsProvider::getDiagnostics instead
+     * @internal
+     */
+    public function getDiagnosticForNode() {
+        return null;
     }
 }

--- a/src/Node/MethodDeclaration.php
+++ b/src/Node/MethodDeclaration.php
@@ -6,6 +6,9 @@
 
 namespace Microsoft\PhpParser\Node;
 
+use Microsoft\PhpParser\Diagnostic;
+use Microsoft\PhpParser\DiagnosticKind;
+use Microsoft\PhpParser\DiagnosticsProvider;
 use Microsoft\PhpParser\FunctionLike;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Token;
@@ -51,5 +54,23 @@ class MethodDeclaration extends Node implements FunctionLike {
 
     public function getName() {
         return $this->name->getText($this->getFileContents());
+    }
+
+    /**
+     * @return Diagnostic|null - Callers should use DiagnosticsProvider::getDiagnostics instead
+     * @internal
+     * @override
+     */
+    public function getDiagnosticForNode() {
+        foreach ($this->modifiers as $modifier) {
+            if ($modifier->kind === TokenKind::VarKeyword) {
+                return new Diagnostic(
+                    DiagnosticKind::Error,
+                    "Unexpected modifier '" . DiagnosticsProvider::getTextForTokenKind($modifier->kind) . "'",
+                    $modifier->start,
+                    $modifier->length
+                );
+            }
+        }
     }
 }

--- a/src/Node/Statement/BreakOrContinueStatement.php
+++ b/src/Node/Statement/BreakOrContinueStatement.php
@@ -6,9 +6,13 @@
 
 namespace Microsoft\PhpParser\Node\Statement;
 
+use Microsoft\PhpParser\Diagnostic;
+use Microsoft\PhpParser\DiagnosticKind;
+use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Node\StatementNode;
 use Microsoft\PhpParser\Token;
+use Microsoft\PhpParser\TokenKind;
 
 class BreakOrContinueStatement extends StatementNode {
     /** @var Token */
@@ -23,4 +27,52 @@ class BreakOrContinueStatement extends StatementNode {
         'breakoutLevel',
         'semicolon'
     ];
+
+    /**
+     * @return Diagnostic|null - Callers should use DiagnosticsProvider::getDiagnostics instead
+     * @internal
+     * @override
+     */
+    public function getDiagnosticForNode() {
+        if ($this->breakoutLevel === null) {
+            return null;
+        }
+
+        $breakoutLevel = $this->breakoutLevel;
+        while ($breakoutLevel instanceof Node\Expression\ParenthesizedExpression) {
+            $breakoutLevel = $breakoutLevel->expression;
+        }
+
+        if (
+            $breakoutLevel instanceof Node\NumericLiteral
+            && $breakoutLevel->children->kind === TokenKind::IntegerLiteralToken
+        ) {
+            $literalString = $breakoutLevel->getText();
+            $firstTwoChars = \substr($literalString, 0, 2);
+
+            if ($firstTwoChars === '0b' || $firstTwoChars === '0B') {
+                if (\bindec(\substr($literalString, 2)) > 0) {
+                    return null;
+                }
+            }
+            else if (\intval($literalString, 0) > 0) {
+                return null;
+            }
+        }
+
+        if ($breakoutLevel instanceof Token) {
+            $start = $breakoutLevel->getStartPosition();
+        }
+        else {
+            $start = $breakoutLevel->getStart();
+        }
+        $end = $breakoutLevel->getEndPosition();
+
+        return new Diagnostic(
+            DiagnosticKind::Error,
+            "Positive integer literal expected.",
+            $start,
+            $end - $start
+        );
+    }
 }

--- a/src/Node/Statement/NamespaceUseDeclaration.php
+++ b/src/Node/Statement/NamespaceUseDeclaration.php
@@ -6,6 +6,9 @@
 
 namespace Microsoft\PhpParser\Node\Statement;
 
+use Microsoft\PhpParser\Diagnostic;
+use Microsoft\PhpParser\DiagnosticKind;
+use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\DelimitedList;
 use Microsoft\PhpParser\Node\StatementNode;
 use Microsoft\PhpParser\Token;
@@ -26,4 +29,27 @@ class NamespaceUseDeclaration extends StatementNode {
         'useClauses',
         'semicolon'
     ];
+
+    /**
+     * @return Diagnostic|null - Callers should use DiagnosticsProvider::getDiagnostics instead
+     * @internal
+     * @override
+     */
+    public function getDiagnosticForNode() {
+        if (
+            $this->useClauses != null
+            && \count($this->useClauses->children) > 1
+        ) {
+            foreach ($this->useClauses->children as $useClause) {
+                if($useClause instanceof Node\NamespaceUseClause && !is_null($useClause->openBrace)) {
+                    return new Diagnostic(
+                        DiagnosticKind::Error,
+                        "; expected.",
+                        $useClause->getEndPosition(),
+                        1
+                    );
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add a simple benchmarking script

Extreme optimization, sacrificing code style in some areas.

- This is meant for discussion, since the project is
  in the optimization phase. Avoiding nested generators did help performance.

This commit reduces the time needed to getDiagnostics
from 0.013 to 0.007 seconds. (On php 7.2.0RC5 with opcache enabled for CLI. Sample file was src/Token.php)

```
Average time to generate diagnostics (before): 0.013...
Average time to generate diagnostics (after):  0.006921
time to parse (Without diagnostics):           0.036374
```

(E.g. getDiagnostics previously took 36% of the time compared to generating an
AST, and now it takes 19% of that time.)