### PR TITLE
Refactoring tests

### DIFF
--- a/tests/ParserGrammarTest.php
+++ b/tests/ParserGrammarTest.php
@@ -100,7 +100,7 @@ class ParserGrammarTest extends TestCase {
         $tokens = str_replace("\r\n", "\n", json_encode($sourceFile, JSON_PRETTY_PRINT));
         file_put_contents($expectedTreeFile, $tokens);
 
-        $this->assertEquals(0, count(DiagnosticsProvider::getDiagnostics($sourceFile)));
+        $this->assertCount(0, DiagnosticsProvider::getDiagnostics($sourceFile));
     }
 
     public function outTreeProvider() {

--- a/tests/api/getResolvedName.php
+++ b/tests/api/getResolvedName.php
@@ -82,7 +82,7 @@ class GetResolvedNameTest extends TestCase {
      */
     public function testGetResolvedName($contents, $expectedName) {
         $node = $this->getNodeAtPosition($contents);
-        $this->assertTrue($node instanceof Node\QualifiedName, "Node is not QualifiedName: " . get_class($node));
+        $this->assertInstanceOf(Node\QualifiedName::class, $node);
 
         $name = $node->getResolvedName();
         $this->assertEquals($expectedName, (string)$name);
@@ -91,7 +91,7 @@ class GetResolvedNameTest extends TestCase {
     private function getNodeAtPosition($contents): Node {
         $parser = new Parser();
         $pos = strpos($contents, '_');
-        $this->assertTrue($pos != FALSE, 'Data is missing underscore');
+        $this->assertNotFalse($pos, 'Data is missing underscore');
         $contents = str_replace('_', '', $contents);
 
         $node = $parser->parseSourceFile($contents);


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertInstanceOf` instead of `instanceof` operator;
- `assertNotFalse` instead of comparison with `false` keyword.