### PR TITLE
Split DiagnosticKind out of Diagnostic.php

### DIFF
--- a/src/Diagnostic.php
+++ b/src/Diagnostic.php
@@ -28,8 +28,3 @@ class Diagnostic {
         $this->length = $length;
     }
 }
-
-class DiagnosticKind {
-    const Error = 0;
-    const Warning = 1;
-}

--- a/src/DiagnosticKind.php
+++ b/src/DiagnosticKind.php
@@ -1,0 +1,12 @@
+<?php
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace Microsoft\PhpParser;
+
+class DiagnosticKind {
+    const Error = 0;
+    const Warning = 1;
+}


### PR DESCRIPTION
E.g. if something using tolerant-php-parser is using DiagnosticKind,
but class diagnostic isn't loaded yet,
then I might fail to load this class.
(If the standard PSR-4 loading rules are used instead of an optimized autoloader)