### PR TITLE
Don't emit "this test did not perform any assertions"

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,4 +1,6 @@
-<phpunit bootstrap="src/bootstrap.php">
+<phpunit bootstrap="src/bootstrap.php"
+	beStrictAboutTestsThatDoNotTestAnything="false"
+	>
   <testsuites>
     <testsuite name="invariants">
       <!--


### PR DESCRIPTION
See https://phpunit.de/manual/current/en/risky-tests.html

I'm using php 7.2.2, and phpunit 6.5.6 gets installed.
I believe that the newer phpunit releases were stricter by default about
tests that don't perform any assertions