### PR TITLE
Workaround for #185 when running tests locally

### DIFF
--- a/tests/ParserGrammarTest.php
+++ b/tests/ParserGrammarTest.php
@@ -79,10 +79,14 @@ class ParserGrammarTest extends TestCase {
     public function treeProvider() {
         $testCases = glob(self::FILE_PATTERN . ".php");
         $skipped = json_decode(file_get_contents(__DIR__ . "/skipped.json"));
+        $hasShortOpenTag = (bool)ini_get('short_open_tag');
 
         $testProviderArray = array();
         foreach ($testCases as $testCase) {
             if (in_array(basename($testCase), $skipped)) {
+                continue;
+            }
+            if ($hasShortOpenTag && in_array(basename($testCase), ['programStructure13.php', 'programStructure21.php'])) {
                 continue;
             }
             $testProviderArray[basename($testCase)] = [$testCase, $testCase . ".tree", $testCase . ".diag"];


### PR DESCRIPTION
This is annoying for developers running unit tests
with short_open_tag enabled
(e.g. if you build php from source with support for that)

- By making this change, this PR ensures that those developers
  don't accidentally commit modified versions of
  programStructure13.php.tree, .diag, etc.

The short_open_tag option cannot be changed at runtime.

An alternative could be to add short_open_tag=0 to phpunit.xml
(But in the future, someone might want to explicitly test the
behavior with short open tags?)