### PR TITLE
Fixed docblock

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -433,7 +433,7 @@ abstract class Node implements \JsonSerializable {
      * Searches descendants to find a Node at the given position.
      *
      * @param $pos
-     * @return Node|null
+     * @return Node
      */
     public function getDescendantNodeAtPosition(int $pos) {
         foreach ($this->getChildNodes() as $child) {


### PR DESCRIPTION
:wave: Doesn't seem possible that this method could return `null`.