### PR TITLE
Fix notices seen in PHP 7.3.0alpha4 (but not alpha3)

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1034,7 +1034,7 @@ class Parser {
                         $expression->children[] = $this->parseExpression($expression);
                     }
                     $expression->children[] = $this->eat1(TokenKind::CloseBraceToken);
-                    continue;
+                    break;
                 case $startQuoteKind = $expression->startQuote->kind:
                 case TokenKind::EndOfFileToken:
                 case TokenKind::HeredocEnd:
@@ -1042,11 +1042,11 @@ class Parser {
                     return $expression;
                 case TokenKind::VariableName:
                     $expression->children[] = $this->parseTemplateStringExpression($expression);
-                    continue;
+                    break;
                 default:
                     $expression->children[] = $this->getCurrentToken();
                     $this->advanceToken();
-                    continue;
+                    break;
             }
         }
     }

--- a/src/PhpTokenizer.php
+++ b/src/PhpTokenizer.php
@@ -86,11 +86,11 @@ class PhpTokenizer implements TokenStreamProviderInterface {
                 case T_OPEN_TAG:
                     $arr[] = new Token(TokenKind::ScriptSectionStartTag, $fullStart, $start, $pos-$fullStart);
                     $start = $fullStart = $pos;
-                    continue;
+                    break;
 
                 case T_WHITESPACE:
                     $start += $strlen;
-                    continue;
+                    break;
 
                 case T_STRING:
                     $name = \strtolower($token[1]);
@@ -98,19 +98,19 @@ class PhpTokenizer implements TokenStreamProviderInterface {
                         $newTokenKind = TokenStringMaps::RESERVED_WORDS[$name];
                         $arr[] = new Token($newTokenKind, $fullStart, $start, $pos - $fullStart);
                         $start = $fullStart = $pos;
-                        continue;
+                        break;
                     }
 
                 default:
                     if (($tokenKind === T_COMMENT || $tokenKind === T_DOC_COMMENT) && $treatCommentsAsTrivia) {
                         $start += $strlen;
-                        continue;
+                        break;
                     }
 
                     $newTokenKind = self::TOKEN_MAP[$tokenKind] ?? TokenKind::Unknown;
                     $arr[] = new Token($newTokenKind, $fullStart, $start, $pos - $fullStart);
                     $start = $fullStart = $pos;
-                    continue;
+                    break;
             }
         }
 


### PR DESCRIPTION
    vendor/microsoft/tolerant-php-parser/src/Parser.php:1037 [2]
    "continue" targeting switch is equivalent to "break".
    Did you mean to use "continue 2"

Could you publish a 0.0.13 release for this? Phan's error handler deliberately terminates the program on PHP notices

See the note in https://github.com/php/php-src/blob/master/UPGRADING about "continue 2"