### PR TITLE
Added missing string return type for QualfiedName#getResolvedName

### DIFF
--- a/src/Node/QualifiedName.php
+++ b/src/Node/QualifiedName.php
@@ -75,7 +75,7 @@ class QualifiedName extends Node implements NamespacedNameInterface {
      * - name resolution is not valid for this element (e.g. part of the name in a namespace definition)
      * - name cannot be resolved (unqualified namespaced function/constant names that are not explicitly imported.)
      *
-     * @return null|ResolvedName
+     * @return null|string|ResolvedName
      * @throws \Exception
      */
     public function getResolvedName($namespaceDefinition = null) {


### PR DESCRIPTION
This PR just fixes a single return type, but I just ran PHPStan on the code base and it picked up this and a multitude of other issues, so I might make a bigger PR addressing as many of those as possible.