### PR TITLE
RFC: Static analysis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ os:
   - linux
 
 matrix:
+  include:
+    - php: 7.2
+      env: STATIC_ANALYSIS=true
   fast_finish: true
   allow_failures:
     - env: VALIDATION=true
@@ -22,6 +25,7 @@ cache:
     - validation/frameworks
 
 before_script:
+  - if [[ $STATIC_ANALYSIS = true ]]; then composer require phpstan/phpstan --no-update; fi
   - composer install
   - set -e # Stop on first error.
   - phpenv config-rm xdebug.ini
@@ -30,7 +34,7 @@ before_script:
 
 script:
   - composer validate
-  - ./vendor/bin/phpstan analyse src --level=2
+  - if [[ $STATIC_ANALYSIS = true ]]; then ./vendor/bin/phpstan analyse src --level=2; fi
   - |
     if [[ $VALIDATION = true ]]; then
       ./vendor/bin/phpunit --testsuite validation

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ before_script:
 
 script:
   - composer validate
+  - ./vendor/bin/phpstan analyse src --level=2
   - |
     if [[ $VALIDATION = true ]]; then
       ./vendor/bin/phpunit --testsuite validation

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
     "type": "library",
     "require": {
-        "php": ">=7.0"
+        "php": ">=7.0",
+        "phpstan/phpstan": "^0.10.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4"

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
         "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4",
-        "phpstan/phpstan": "^0.10.2"
+        "phpunit/phpunit": "^6.4"
     },
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,11 @@
     "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
     "type": "library",
     "require": {
-        "php": ">=7.0",
-        "phpstan/phpstan": "^0.10.2"
+        "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^6.4",
+        "phpstan/phpstan": "^0.10.2"
     },
     "license": "MIT",
     "authors": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,6 @@
+parameters:
+    ignoreErrors:
+        # phpstan issue, see: https://github.com/phpstan/phpstan/issues/1306
+        - "/Variable .unaryExpression might not be defined./"
+        - "/Variable .passedPrefix might not be defined./"
+        - "/Variable .prefix might not be defined./"

--- a/src/Node.php
+++ b/src/Node.php
@@ -13,6 +13,8 @@ use Microsoft\PhpParser\Node\Statement\NamespaceDefinition;
 use Microsoft\PhpParser\Node\Statement\NamespaceUseDeclaration;
 
 abstract class Node implements \JsonSerializable {
+    const CHILD_NAMES = [];
+
     /** @var array[] Map from node class to array of child keys */
     private static $childNames = [];
 

--- a/src/Node.php
+++ b/src/Node.php
@@ -48,23 +48,29 @@ abstract class Node implements \JsonSerializable {
      */
     public function getFullStart() : int {
         foreach($this::CHILD_NAMES as $name) {
+
             if (($child = $this->$name) !== null) {
+
                 if (\is_array($child)) {
                     if(!isset($child[0])) {
                         continue;
                     }
                     $child = $child[0];
                 }
+
                 if ($child instanceof Node) {
                     return $child->getFullStart();
-                } elseif ($child instanceof Token) {
+                }
+
+                if ($child instanceof Token) {
                     return $child->fullStart;
                 }
+
                 throw new \Exception("Unknown type in AST: " . \gettype($child));
             }
         };
 
-        throw new \Exception("Unknown type in AST: " . \gettype($child));
+        throw new \RuntimeException("Could not resolve full start position");
     }
 
     /**

--- a/src/Node.php
+++ b/src/Node.php
@@ -440,7 +440,7 @@ abstract class Node implements \JsonSerializable {
     /**
      * Searches descendants to find a Node at the given position.
      *
-     * @param $pos
+     * @param int $pos
      * @return Node
      */
     public function getDescendantNodeAtPosition(int $pos) {

--- a/src/Node/Statement/NamespaceDefinition.php
+++ b/src/Node/Statement/NamespaceDefinition.php
@@ -9,7 +9,11 @@ namespace Microsoft\PhpParser\Node\Statement;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Node\StatementNode;
 use Microsoft\PhpParser\Token;
+use Microsoft\PhpParser\Node\SourceFileNode;
 
+/**
+ * @property SourceFileNode $parent
+ */
 class NamespaceDefinition extends StatementNode {
     /** @var Token */
     public $namespaceKeyword;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -48,6 +48,7 @@ use Microsoft\PhpParser\Node\Expression\{
     Variable,
     YieldExpression
 };
+use Microsoft\PhpParser\Node\FunctionHeader;
 use Microsoft\PhpParser\Node\StaticVariableDeclaration;
 use Microsoft\PhpParser\Node\ClassConstDeclaration;
 use Microsoft\PhpParser\Node\DeclareDirective;
@@ -183,7 +184,7 @@ class Parser {
      * with that ParseContext is reached. Additionally abort parsing when an element is reached
      * that is invalid in the current context, but valid in an enclosing context. If an element
      * is invalid in both current and enclosing contexts, generate a SkippedToken, and continue.
-     * @param $parentNode
+     * @param Node $parentNode
      * @param int $listParseContext
      * @return array
      */
@@ -1335,7 +1336,11 @@ class Parser {
         return null;
     }
 
+    /**
+     * @param MethodDeclaration|FunctionDeclaration|AnonymousFunctionCreationExpression $functionDeclaration
+     */
     private function parseFunctionType(Node $functionDeclaration, $canBeAbstract = false, $isAnonymous = false) {
+
         $functionDeclaration->functionKeyword = $this->eat1(TokenKind::FunctionKeyword);
         $functionDeclaration->byRefToken = $this->eatOptional1(TokenKind::AmpersandToken);
         $functionDeclaration->name = $isAnonymous

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1886,7 +1886,7 @@ class Parser {
         $rightOperand->parent = $binaryExpression;
         $binaryExpression->leftOperand = $leftOperand;
         $binaryExpression->operator = $operatorToken;
-        if (isset($byRefToken)) {
+        if ($binaryExpression instanceof AssignmentExpression && isset($byRefToken)) {
             $binaryExpression->byRef = $byRefToken;
         }
         $binaryExpression->rightOperand = $rightOperand;

--- a/src/PositionUtilities.php
+++ b/src/PositionUtilities.php
@@ -12,13 +12,8 @@ class PositionUtilities {
 
      * Out of bounds positions are handled gracefully. Positions greater than the length of text length
      * are resolved to the end of the text, and negative positions are resolved to the beginning.
-     *
-     * @param $pos
-     * @param $length
-     * @param $text
-     * @return Range
      */
-    public static function getRangeFromPosition($pos, $length, $text): Range {
+    public static function getRangeFromPosition(int $pos, int $length, string $text): Range {
         $start = self::getLineCharacterPositionFromPosition($pos, $text);
         $end = self::getLineCharacterPositionFromPosition($pos + $length, $text);
 
@@ -31,12 +26,8 @@ class PositionUtilities {
      * Out of bounds positions are handled gracefully. Positions greater than the length of text length
      * are resolved to text length, and negative positions are resolved to 0.
      * TODO consider throwing exception instead.
-     *
-     * @param $pos
-     * @param $text
-     * @return LineCharacterPosition
      */
-    public static function getLineCharacterPositionFromPosition($pos, $text) : LineCharacterPosition {
+    public static function getLineCharacterPositionFromPosition(int $pos, string $text) : LineCharacterPosition {
         $textLength = \strlen($text);
         if ($pos >= $textLength) {
             $pos = $textLength;

--- a/src/Token.php
+++ b/src/Token.php
@@ -72,8 +72,11 @@ class Token implements \JsonSerializable {
     }
 
     /**
+     * Returns the token kind name as a string, or the token number if the name
+     * was not found.
+     *
      * @param int $kind
-     * @return string (Or int, if the kind name for $kind wasn't found)
+     * @return int|string 
      */
     public static function getTokenKindNameFromValue($kind) {
         $mapToKindName = self::getTokenKindNameFromValueMap();


### PR DESCRIPTION
This PR introduces PHPStan and fixes the code up to level 2 (out of 7).

- [x] Various fixes for static analysis
- [x] Introduces PHPStan in the Travis build

There remain 84 errors at `--level=7` (there were 117 before this PR)

--

PHPStan is `>=7.1` only, in `.travis.yml` it (should be) configured to run only on the 7.2 build.


