### PR TITLE
Move PHPStan configuration to its file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
 
 script:
   - composer validate
-  - if [[ $STATIC_ANALYSIS = true ]]; then ./vendor/bin/phpstan analyse src --level=2; fi
+  - if [[ $STATIC_ANALYSIS = true ]]; then ./vendor/bin/phpstan analyse; fi
   - |
     if [[ $VALIDATION = true ]]; then
       ./vendor/bin/phpunit --testsuite validation

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,7 @@
 parameters:
+    level: 2
+    paths:
+        - src/
     ignoreErrors:
         # phpstan issue, see: https://github.com/phpstan/phpstan/issues/1306
         - "/Variable .unaryExpression might not be defined./"


### PR DESCRIPTION
With this patch, we can make the usage of PHPStan both locally and in our CI easier. Instead of figure out what paths and level we're using in the project, one can just do the following now:

```bash
$ composer require --dev phpstan/phpstan
$ vendor/bin/phpstan analyze
```