### PR TITLE
Use fully qualified substr in Token.php

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -6,6 +6,8 @@
 
 namespace Microsoft\PhpParser;
 
+use function substr;
+
 class Token implements \JsonSerializable {
     // TODO optimize memory - ideally this would be a struct of 4 ints
     public $kind;


### PR DESCRIPTION
Token->getText() will be called frequently in some applications.

This is slightly more efficient; the php interpreter can cache the address of the C function object when the namespace of the function is unambiguous.