### PR TITLE
Add micro-optimizations

### DIFF
--- a/src/Node/DelimitedList.php
+++ b/src/Node/DelimitedList.php
@@ -43,7 +43,8 @@ abstract class DelimitedList extends Node {
             return;
         }
         if ($this->children === null) {
-            $this->children = [];
+            $this->children = [$node];
+            return;
         }
         $this->children[] = $node;
     }

--- a/src/PhpTokenizer.php
+++ b/src/PhpTokenizer.php
@@ -83,16 +83,16 @@ class PhpTokenizer implements TokenStreamProviderInterface {
             }
 
             switch ($tokenKind) {
-                case T_OPEN_TAG:
+                case \T_OPEN_TAG:
                     $arr[] = new Token(TokenKind::ScriptSectionStartTag, $fullStart, $start, $pos-$fullStart);
                     $start = $fullStart = $pos;
                     break;
 
-                case T_WHITESPACE:
+                case \T_WHITESPACE:
                     $start += $strlen;
                     break;
 
-                case T_STRING:
+                case \T_STRING:
                     $name = \strtolower($token[1]);
                     if (isset(TokenStringMaps::RESERVED_WORDS[$name])) {
                         $newTokenKind = TokenStringMaps::RESERVED_WORDS[$name];
@@ -102,7 +102,7 @@ class PhpTokenizer implements TokenStreamProviderInterface {
                     }
 
                 default:
-                    if (($tokenKind === T_COMMENT || $tokenKind === T_DOC_COMMENT) && $treatCommentsAsTrivia) {
+                    if (($tokenKind === \T_COMMENT || $tokenKind === \T_DOC_COMMENT) && $treatCommentsAsTrivia) {
                         $start += $strlen;
                         break;
                     }


### PR DESCRIPTION
When constants aren't fully qualified, the php interpreter has to check both the current namespace (Microsoft\TolerantPHPParser) and the global namespace for that constant. It does that every loop iteration (e.g. for every token in that file).

- When the constant is fully qualified, the php interpreter can replace the internal constant access with its integer value in the bytecode.
- Phan has a plugin that can detect uses of functions/constants that aren't fully qualified - see https://github.com/phan/phan/blob/master/.phan/plugins/NotFullyQualifiedUsagePlugin.php

Also, combine creating an array and appending to that array in DelimitedList, because it's used frequently (statement lists, argument lists, param lists, etc.)

Related to #15