### PR TITLE
Optimizations to PhpTokenizer

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,5 +5,4 @@ parameters:
     ignoreErrors:
         # phpstan issue, see: https://github.com/phpstan/phpstan/issues/1306
         - "/Variable .unaryExpression might not be defined./"
-        - "/Variable .passedPrefix might not be defined./"
         - "/Variable .prefix might not be defined./"


### PR DESCRIPTION
Speeds up parsing speed by a few percentage points.

- Move skipping prefix out of the loop.
  It isn't used except when getting doc comments, which is much less
  common than getting all tokens
- Handle strings separately from arrays in token_get_all.
- Move `if` within a switch to its own case.