### PR TITLE
Group tokens logic 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tests/output
 *.ast
 .*.swp
 .*.swo
+/nbproject/private/

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ tests/output
 *.ast
 .*.swp
 .*.swo
-/nbproject/private/
+/nbproject/

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -42,6 +42,9 @@
     <testsuite name="performance">
       <!-- TODO: Validates that there are no performance regressions. -->
     </testsuite>
+    <testsuite name="tokens">
+      <file>tests/cases/tokens/TokenTest.php</file>
+    </testsuite>
   </testsuites>
 
   <filter>

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1319,7 +1319,7 @@ class Parser {
      *
      * @param int $kind
      */
-    private function lookAhead1($kind)
+    private function lookahead1($kind)
     {
         $startPos = $this->lexer->getCurrentPosition();
         $startToken = $this->token;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -473,7 +473,7 @@ class Parser {
 
                 // labeled-statement
                 case TokenKind::Name:
-                    if ($this->lookahead(TokenKind::ColonToken)) {
+                    if ($this->lookahead1(TokenKind::ColonToken)) {
                         return $this->parseNamedLabelStatement($parentNode);
                     }
                     break;
@@ -524,7 +524,7 @@ class Parser {
                 // class-declaration
                 case TokenKind::FinalKeyword:
                 case TokenKind::AbstractKeyword:
-                    if (!$this->lookahead(TokenKind::ClassKeyword)) {
+                    if (!$this->lookahead1(TokenKind::ClassKeyword)) {
                         $this->advanceToken();
                         return new SkippedToken($token);
                     }
@@ -537,7 +537,7 @@ class Parser {
 
                 // namespace-definition
                 case TokenKind::NamespaceKeyword:
-                    if (!$this->lookahead(TokenKind::BackslashToken)) {
+                    if (!$this->lookahead1(TokenKind::BackslashToken)) {
                         // TODO add error handling for the case where a namespace definition does not occur in the outer-most scope
                         return $this->parseNamespaceDefinition($parentNode);
                     }
@@ -1100,7 +1100,7 @@ class Parser {
             }
 
             // scalar-type
-            return \in_array($token->kind, $this->parameterTypeDeclarationTokens);
+            return $token->isParameterTypeDeclaration();
         };
     }
 
@@ -1195,12 +1195,12 @@ class Parser {
                         // a\b\true <-VALID
                         // a\static::b <-VALID
                         // TODO more tests
-                        return $this->lookahead(TokenKind::BackslashToken)
-                            ? in_array($token->kind, $this->nameOrReservedWordTokens)
-                            : in_array($token->kind, $this->nameOrStaticOrReservedWordTokens);
+                        return $this->lookahead1(TokenKind::BackslashToken)
+                            ? $token->isNameOrReserved()
+                            : $token->isNameOrStaticOrReserved();
                     },
                     function ($parentNode) {
-                        $name = $this->lookahead(TokenKind::BackslashToken)
+                        $name = $this->lookahead1(TokenKind::BackslashToken)
                             ? $this->eat($this->nameOrReservedWordTokens)
                             : $this->eat($this->nameOrStaticOrReservedWordTokens); // TODO support keyword name
                         $name->kind = TokenKind::Name; // bool/true/null/static should not be treated as keywords in this case
@@ -1290,7 +1290,7 @@ class Parser {
         $startPos = $this->lexer->getCurrentPosition();
         $startToken = $this->token;
         $succeeded = true;
-        $expectedKinds = [6, 7];
+
         foreach ($expectedKinds as $kind) {
             $token = $this->lexer->scanNextToken();
             $currentPosition = $this->lexer->getCurrentPosition();

--- a/src/Token.php
+++ b/src/Token.php
@@ -131,4 +131,62 @@ class Token implements \JsonSerializable {
             ];
         }
     }
+
+    public function isKeyword(): bool
+    {
+        return TokenKind::isKeyword($this->kind);
+    }
+
+    public function isReserved(): bool
+    {
+        return TokenKind::isReserved($this->kind);
+    }
+
+    public function isNameOrReserved(): bool
+    {
+        return TokenKind::Name || TokenKind::isReserved($this->kind);
+    }
+    
+    public function isNameOrKeywordOrReserved(): bool
+    {
+        return TokenKind::isNameOrKeywordOrReserved($this->kind);
+    }
+    
+    public function isNameOrStaticOrReserved()
+    {
+        return TokenKind::Name || TokenKind::StaticKeyword || $this->isReserved();
+    }
+    
+    public function isReturnTypeDeclaration(): bool
+    {
+        return TokenKind::VoidReservedWord || TokenKind::isParameterTypeDeclaration($this->kind);
+    }
+    
+    public function isParameterTypeDeclaration(): bool
+    {
+        return TokenKind::isParameterTypeDeclaration($this->kind);
+    }
+    
+    /**
+     * Missing tokens in this functions are
+     * TokenKind::Name
+     * TokenKind::ArrayKeyword
+     * TokenKind::NamespaceKeyword
+     * @return bool
+     */
+    public function isExpressionStart(): bool
+    {
+        return TokenKind::isExpression($this->kind);
+    }
+    
+    /**
+     * Missing tokens in this functions are
+     * TokenKind::Name
+     * TokenKind::AbstractKeyword
+     * @return bool
+     */
+    public function isStatementStart(): bool
+    {
+        return TokenKind::isStatement($this->kind);
+    }
 }

--- a/src/Token/Compiler.php
+++ b/src/Token/Compiler.php
@@ -7,7 +7,7 @@ namespace Microsoft\PhpParser\Token;
  * Borrowed from Twig's compiler
  */
 class Compiler {
-    
+
     /**
      * @var int
      */
@@ -35,11 +35,7 @@ class Compiler {
         return $this->source;
     }
 
-    public function compile(array $tokens, int $indentation = 0)
-    {
-    }
-
-        /**
+    /**
      * Adds a raw string to the compiled code.
      *
      * @param string $string The string

--- a/src/Token/Compiler.php
+++ b/src/Token/Compiler.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Microsoft\PhpParser\Token;
+
+/**
+ * Helps to compile PHP code
+ * Borrowed from Twig's compiler
+ */
+class Compiler {
+    
+    /**
+     * @var int
+     */
+    private $indentation;
+
+    /**
+     * @var string
+     */
+    private $source;
+
+
+    public function __construct(int $indentation = 0)
+    {
+        $this->indentation = $indentation;
+
+        $this->source = '';
+
+    }
+
+    /**
+     * @return string
+     */
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    public function compile(array $tokens, int $indentation = 0)
+    {
+    }
+
+        /**
+     * Adds a raw string to the compiled code.
+     *
+     * @param string $string The string
+     *
+     * @return $this
+     */
+    public function raw($string)
+    {
+        $this->source .= $string;
+
+        return $this;
+    }
+
+    public function writeLine(...$strings)
+    {
+        $this->write($strings);
+        $this->source .= "\n";
+        return $this;
+    }
+
+    public function write(...$strings)
+    {
+        foreach ($strings as $string) {
+            $this->source .= str_repeat(' ', $this->indentation * 4) . $string;
+        }
+        return $this;
+    }
+
+    /**
+     * Adds a quoted string to the compiled code.
+     *
+     * @param string $value The string
+     *
+     * @return $this
+     */
+    public function string($value)
+    {
+        $this->source .= sprintf('"%s"', addcslashes($value, "\0\t\"\$\\"));
+
+        return $this;
+    }
+
+    /**
+     * Returns a PHP representation of a given value.
+     *
+     * @param mixed $value The value to convert
+     *
+     * @return $this
+     */
+    public function repr($value)
+    {
+        if (\is_int($value) || \is_float($value)) {
+            if (false !== $locale = setlocale(LC_NUMERIC, '0')) {
+                setlocale(LC_NUMERIC, 'C');
+            }
+
+            $this->raw(var_export($value, true));
+
+            if (false !== $locale) {
+                setlocale(LC_NUMERIC, $locale);
+            }
+        } elseif (null === $value) {
+            $this->raw('null');
+        } elseif (\is_bool($value)) {
+            $this->raw($value ? 'true' : 'false');
+        } elseif (\is_array($value)) {
+            $this->raw('array(');
+            $first = true;
+            foreach ($value as $key => $v) {
+                if (!$first) {
+                    $this->raw(', ');
+                }
+                $first = false;
+                $this->repr($key);
+                $this->raw(' => ');
+                $this->repr($v);
+            }
+            $this->raw(')');
+        } else {
+            $this->string($value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Indents the generated code.
+     *
+     * @param int $step The number of indentation to add
+     *
+     * @return $this
+     */
+    public function indent($step = 1)
+    {
+        $this->indentation += $step;
+
+        return $this;
+    }
+
+    /**
+     * Outdents the generated code.
+     *
+     * @param int $step The number of indentation to remove
+     *
+     * @return $this
+     *
+     * @throws \LogicException When trying to outdent too much so the indentation would become negative
+     */
+    public function outdent($step = 1)
+    {
+        // can't outdent by more steps than the current indentation level
+        if ($this->indentation < $step) {
+            throw new \LogicException('Unable to call outdent() as the indentation would become negative.');
+        }
+
+        $this->indentation -= $step;
+
+        return $this;
+    }
+}

--- a/src/Token/FunctionConstructor.php
+++ b/src/Token/FunctionConstructor.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace Microsoft\PhpParser\Token;
+
+class FunctionConstructor
+{
+
+    /**
+     * @var string
+     */
+    private $beginKey;
+
+    /**
+     * @var string
+     */
+    private $endKey;
+
+    /**
+     * @var array
+     */
+    private $begin;
+
+    /**
+     * @var array
+     */
+    private $end;
+
+    /**
+     * @var string
+     */
+    private $last = '';
+
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $tokenName;
+
+    public function __construct(string $token, string $beginKey, string $endKey, string $prefix = 'is')
+    {
+        $this->edges = [];
+        $this->beginKey = $beginKey;
+        $this->endKey = $endKey;
+        $this->prefix = $prefix;
+        $this->name = $this->createFunctionName($token);
+        $this->tokenName = str_replace($this->getKeyWords(), '', $token);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    private function getKeyWords()
+    {
+        return [$this->beginKey, $this->endKey];
+    }
+
+    public function setValue(string $token, $value)
+    {
+        $this->checkCall($token);
+        $this->last = $token;
+
+        $keyword = trim(str_replace($this->tokenName, '', $token));
+        switch ($keyword) {
+            case $this->beginKey:
+                $this->begin[] = $value;
+                break;
+            case $this->endKey:
+                $this->end[] = $value;
+                break;
+            default:
+                throw new Exception("Can't handle $keyword.");
+        }
+    }
+
+    private function checkCall(string $token)
+    {
+        if (false === strpos($token, $this->tokenName)) {
+            throw new Exception("'$token' mismatch function '{$this->name}'.");
+        }
+
+        if ($this->last === $token) {
+            throw new Exception("Can't call '$token' twice.");
+        }
+    }
+
+    private function createFunctionName(string $token): string
+    {
+        $token = str_replace($this->getKeyWords(), "", $token);
+        $method = $this->prefix;
+        foreach (explode('_', $token) as $tok) {
+            $method .= ucfirst(strtolower($tok));
+        }
+        return $method;
+    }
+
+    public function isEndKeyword(string $token): bool
+    {
+        return $this->endKey . $this->tokenName === $token;
+    }
+
+    /**
+     * 
+     * @param Compiler $compiler
+     * @param array $tokens array(value => name)
+     */
+    public function compile(Compiler $compiler, array $tokens)
+    {
+        $param = '$tokenKind';
+        $compiler->write("public static function {$this->name}(int $param): bool\n")
+                ->write("{\n")
+                ->indent();
+        $this->writeFunctionBody($param, $compiler, $tokens);
+        $compiler->outdent()->write("}\n\n");
+    }
+
+    private function writeFunctionBody(string $param, Compiler $compiler, array $tokens)
+    {
+        $len = count($this->begin);
+        if (count($this->begin) !== count($this->end)) {
+            throw new Exception(sprintf("Mismatch begin with end edges in function %s related to %s.", $this->name, $this->tokenName));
+        }
+        if ($len === 0) {
+            throw new Exception("Can't compile an empty function.");
+        }
+        $parts = [];
+        for ($i = 0; $i < $len; $i++) {
+            $parts[] = $this->getCondition($i, $param, $tokens);
+        }
+        $condition = implode(") || (", $parts);
+        $condition = count($parts) > 1 ? "($condition)" : $condition;
+        $compiler->write("return $condition;\n");
+    }
+
+    /**
+     * 
+     * @param int $i
+     * @param string $param
+     * @param array $tokens
+     */
+    private function getCondition(int $i, string $param, array $tokens): string
+    {
+        $begin = $this->begin[$i];
+        $end = $this->end[$i];        
+        $condition = "$begin < $param && $param < $end";
+        
+        $tokensInRange = $this->getTokensInRange($tokens, $begin, $end);
+        
+        if (count($tokensInRange) === 1) {
+            $exactly = current($tokensInRange);
+            $condition = "$exactly === $param";
+        }
+        
+        return $condition;
+    }
+
+    /**
+     * 
+     * @param array $tokens
+     * @param int $begin
+     * @param int $end
+     * @return array
+     */
+    private function getTokensInRange(array $tokens, int $begin, int $end): array
+    {
+        $inRange = [];
+        foreach ($tokens as $tok => $const) {
+            if ($begin < $const && $const < $end) {
+                $inRange[$tok] = $const;
+            }
+        }
+        return $inRange;
+    }
+}

--- a/src/Token/TokenCompiler.php
+++ b/src/Token/TokenCompiler.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Microsoft\PhpParser\Token;
+
+class TokenCompiler {
+
+    /**
+     * @var Compiler
+     */
+    private $compiler;
+
+    /**
+     * @var int
+     */
+    private $counter;
+
+    /**
+     * @var FunctionConstructor[]
+     */
+    private $functions;
+
+    /**
+     * @var int
+     */
+    private $lastValue;
+
+    /**
+     * @var callable
+     */
+    private $onNext = [];
+    
+    /**
+     *
+     * @var array 
+     */
+    private $tokens = [];
+
+    private $keywords = ["begin_", "end_"];
+
+    public function __construct(Compiler $compiler, int $counter = 0)
+    {
+        $this->compiler = $compiler;
+        $this->counter = $counter;
+    }
+
+    public function compile(array $tokens): string
+    {
+        $namespace = 'Microsoft\PhpParser';
+        $header = <<<EOD
+<?php
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+namespace $namespace;
+
+class TokenKind {\n
+EOD;
+        $this->compiler->raw($header);
+        $this->compiler->indent();
+
+        foreach ($tokens as $token) {
+
+            $found = $this->checkWords($token, $this->keywords);
+
+            if ($this->checkWord($token, "jump")) {
+                $newCounter = (int) trim(str_replace('jump', '', $token));
+                $this->counter = $newCounter;
+                continue;
+            }
+
+            if ($this->checkWord($token, "TODO")) {
+                $this->compiler->write("// $token\n");
+                continue;
+            }
+
+            if ($this->checkWord($token, "comment")) {
+                $token = trim(str_replace("comment", "", $token));
+                $this->compiler->write("// $token\n");
+                continue;
+            }
+
+            if ($found) {
+                $this->addFunction($token, $this->lastValue);
+                $this->compiler->write("// $token\n");
+                continue;
+            }
+
+            $this->lastValue = $value = $this->generateValue();
+
+            if ($this->onNext) {
+                $this->callOnNext($token, $value);
+            }
+            $this->tokens[$token] = $value;
+            $this->compiler->write("const $token = $value;\n");
+        }
+        
+        $this->compiler->raw("\n");
+
+        foreach ($this->functions as $func => $instance) {
+            $instance->compile($this->compiler, $this->tokens);
+        }
+
+        $this->compiler->outdent();
+        $this->compiler->write("}\n");
+        return $this->compiler->getSource();
+    }
+
+    /**
+     *
+     * @param string $token
+     * @param int $value
+     * @return $this
+     */
+    private function addFunction(string $token, int $value)
+    {
+        $func = new FunctionConstructor($token, ...$this->keywords);
+        $name = $func->getName();
+
+        if (!isset($this->functions[$name])) {
+            $this->functions[$name] = $func;
+        } else {
+            $func = $this->functions[$name];
+        }
+
+        if ($func->isEndKeyword($token)) {
+            $this->addOnNext(function($tok, $val) use ($func, $token){
+                $func->setValue($token, $val);
+            });
+            return $this;
+        }
+
+        $func->setValue($token, $value);
+
+        return $this;
+    }
+
+    public function addOnNext(callable $func)
+    {
+        $this->onNext[] = $func;
+        return $this;
+    }
+
+    public function callOnNext(string $token, $value)
+    {
+        foreach ($this->onNext as $func) {
+            $func($token, $value);
+        }
+        $this->onNext = [];
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function generateValue(): int
+    {
+        return $this->counter++;
+    }
+
+    private function checkWord(string $token, string $word) {
+        if (false === strpos($token, $word)) {
+            return false;
+        }
+        $this->compiler->raw("\n");
+        return true;
+    }
+
+    private function checkWords(string $token, array $words)
+    {
+        foreach ($words as $word) {
+            if ($this->checkWord($token, $word)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/TokenKind.php
+++ b/src/TokenKind.php
@@ -10,205 +10,308 @@ class TokenKind {
     const Unknown = 0;
     const EndOfFileToken = 1;
 
-    const Name = 2;
-    const VariableName = 3;
+    // begin_expression
+    const VariableName = 2;
 
-    const SkippedToken = 4;
-    const MissingToken = 5;
-    const QualifiedName = 6;
+    // end_expression
+    const SkippedToken = 3;
+    const MissingToken = 4;
+    const QualifiedName = 5;
+
+    // begin_name_or_keyword_or_reserved
+    const Name = 6;
 
 
-    const AbstractKeyword = 101;
-    const AndKeyword = 102;
-    const ArrayKeyword = 103;
-    const AsKeyword = 104;
-    const BreakKeyword = 105;
-    const CallableKeyword = 106;
-    const CaseKeyword = 107;
-    const CatchKeyword = 108;
-    const ClassKeyword = 109;
-    const CloneKeyword = 110;
-    const ConstKeyword = 111;
-    const ContinueKeyword = 112;
-    const DeclareKeyword = 113;
-    const DefaultKeyword = 114;
-    const DieKeyword = 115;
-    const DoKeyword = 116;
-    const EchoKeyword = 117;
-    const ElseKeyword = 118;
-    const ElseIfKeyword = 119;
-    const EmptyKeyword = 120;
-    const EndDeclareKeyword = 121;
-    const EndForKeyword = 122;
-    const EndForEachKeyword = 123;
-    const EndIfKeyword = 124;
-    const EndSwitchKeyword = 125;
-    const EndWhileKeyword = 126;
-    const EvalKeyword = 127;
-    const ExitKeyword = 128;
-    const ExtendsKeyword = 129;
-    const FinalKeyword = 130;
-    const FinallyKeyword = 131;
-    const ForKeyword = 132;
-    const ForeachKeyword = 133;
-    const FunctionKeyword = 134;
-    const GlobalKeyword = 135;
-    const GotoKeyword = 136;
-    const IfKeyword = 137;
-    const ImplementsKeyword = 138;
-    const IncludeKeyword = 139;
-    const IncludeOnceKeyword = 140;
-    const InstanceOfKeyword = 141;
-    const InsteadOfKeyword = 142;
-    const InterfaceKeyword = 143;
-    const IsSetKeyword = 144;
-    const ListKeyword = 145;
-    const NamespaceKeyword = 146;
-    const NewKeyword = 147;
-    const OrKeyword = 148;
-    const PrintKeyword = 149;
-    const PrivateKeyword = 150;
-    const ProtectedKeyword = 151;
-    const PublicKeyword = 152;
-    const RequireKeyword = 153;
-    const RequireOnceKeyword = 154;
-    const ReturnKeyword = 155;
-    const StaticKeyword = 156;
-    const SwitchKeyword = 157;
-    const ThrowKeyword = 158;
-    const TraitKeyword = 159;
-    const TryKeyword = 160;
-    const UnsetKeyword = 161;
-    const UseKeyword = 162;
-    const VarKeyword = 163;
-    const WhileKeyword = 164;
-    const XorKeyword = 165;
-    const YieldKeyword = 166;
-    const YieldFromKeyword = 167;
-    const FnKeyword = 168;
+    // begin_keyword
+    const AbstractKeyword = 100;
+    const AndKeyword = 101;
 
-    const OpenBracketToken = 201;
-    const CloseBracketToken = 202;
-    const OpenParenToken = 203;
-    const CloseParenToken = 204;
-    const OpenBraceToken = 205;
-    const CloseBraceToken = 206;
-    const DotToken = 207;
-    const ArrowToken = 208;
-    const PlusPlusToken = 209;
-    const MinusMinusToken = 210;
-    const AsteriskAsteriskToken = 211;
-    const AsteriskToken = 212;
-    const PlusToken = 213;
-    const MinusToken = 214;
-    const TildeToken = 215;
-    const ExclamationToken = 216;
-    const DollarToken = 217;
-    const SlashToken = 218;
-    const PercentToken = 220;
-    const LessThanLessThanToken = 221;
-    const GreaterThanGreaterThanToken = 222;
-    const LessThanToken = 223;
-    const GreaterThanToken = 224;
-    const LessThanEqualsToken = 225;
-    const GreaterThanEqualsToken = 226;
-    const EqualsEqualsToken = 227;
-    const EqualsEqualsEqualsToken = 228;
-    const ExclamationEqualsToken = 229;
-    const ExclamationEqualsEqualsToken = 230;
-    const CaretToken = 231;
-    const BarToken = 232;
-    const AmpersandToken = 233;
-    const AmpersandAmpersandToken = 234;
-    const BarBarToken = 235;
-    const ColonToken = 236;
-    const SemicolonToken = 237;
-    const EqualsToken = 238;
-    const AsteriskAsteriskEqualsToken = 239;
-    const AsteriskEqualsToken = 240;
-    const SlashEqualsToken = 241;
-    const PercentEqualsToken = 242;
-    const PlusEqualsToken = 243;
-    const MinusEqualsToken = 244;
-    const DotEqualsToken = 245;
-    const LessThanLessThanEqualsToken = 246;
-    const GreaterThanGreaterThanEqualsToken = 247;
-    const AmpersandEqualsToken = 248;
-    const CaretEqualsToken = 249;
-    const BarEqualsToken = 250;
-    const CommaToken = 251;
-    const QuestionQuestionToken = 252;
-    const LessThanEqualsGreaterThanToken = 253;
-    const DotDotDotToken = 254;
-    const BackslashToken = 255;
-    const ColonColonToken = 256;
-    const DoubleArrowToken = 257; // TODO missing from spec
-    const LessThanGreaterThanToken = 258; // TODO missing from spec
-    const AtSymbolToken = 259;
-    const BacktickToken = 260;
-    const QuestionToken = 261;
-    const QuestionQuestionEqualsToken = 262;
+    // begin_parameter_type_declaration
+    const ArrayKeyword = 102;
+    const CallableKeyword = 103;
 
-    const DecimalLiteralToken = 301;
-    const OctalLiteralToken = 302;
-    const HexadecimalLiteralToken = 303;
-    const BinaryLiteralToken = 304;
-    const FloatingLiteralToken = 305;
-    const InvalidOctalLiteralToken = 306;
-    const InvalidHexadecimalLiteral = 307;
-    const InvalidBinaryLiteral = 308;
-    const StringLiteralToken = 309;
+    // end_parameter_type_declaration
 
-    // RESERVED WORDS
-    const IntReservedWord = 317;
-    const FloatReservedWord = 318;
-    const TrueReservedWord = 319;
-    const StringReservedWord = 320;
-    const BoolReservedWord = 321;
-    const NullReservedWord = 322;
+    // begin_statement
+    const IfKeyword = 104;
+    const SwitchKeyword = 105;
+    const WhileKeyword = 106;
+    const DoKeyword = 107;
+    const ForKeyword = 108;
+    const ForeachKeyword = 109;
+    const GotoKeyword = 110;
+    const ContinueKeyword = 111;
+    const BreakKeyword = 112;
+    const ReturnKeyword = 113;
+    const ThrowKeyword = 114;
+    const TryKeyword = 115;
+    const DeclareKeyword = 116;
+    const ConstKeyword = 117;
+    const ClassKeyword = 118;
+    const FinalKeyword = 119;
+    const InterfaceKeyword = 120;
+    const TraitKeyword = 121;
+    const NamespaceKeyword = 122;
+    const UseKeyword = 123;
+    const GlobalKeyword = 124;
 
-    const ScriptSectionStartTag = 323;
-    const ScriptSectionEndTag = 324;
-    const ScriptSectionStartWithEchoTag = 419;
+    // end_statement
+    const AsKeyword = 125;
+    const CaseKeyword = 126;
+    const CatchKeyword = 127;
+    const DefaultKeyword = 128;
+    const ElseKeyword = 129;
+    const ElseIfKeyword = 130;
+    const EndDeclareKeyword = 131;
+    const EndForKeyword = 132;
+    const EndForEachKeyword = 133;
+    const EndIfKeyword = 134;
+    const EndSwitchKeyword = 135;
+    const EndWhileKeyword = 136;
+    const ExtendsKeyword = 137;
+    const FinallyKeyword = 138;
+    const ImplementsKeyword = 139;
+    const InstanceOfKeyword = 140;
+    const InsteadOfKeyword = 141;
+    const OrKeyword = 142;
+    const PrivateKeyword = 143;
+    const ProtectedKeyword = 144;
+    const PublicKeyword = 145;
+    const VarKeyword = 146;
+    const XorKeyword = 147;
+
+    // begin_expression
+
+    // script inclusion expression
+    const RequireKeyword = 148;
+    const RequireOnceKeyword = 149;
+    const IncludeKeyword = 150;
+    const IncludeOnceKeyword = 151;
+
+    // yield expression
+    const YieldKeyword = 152;
+    const YieldFromKeyword = 153;
+
+    // object creation expression
+    const CloneKeyword = 154;
+    const NewKeyword = 155;
+
+    // intrinsic constructor
+    const EchoKeyword = 156;
+    const ListKeyword = 157;
+    const UnsetKeyword = 158;
+
+    // intrinsic operator
+    const EmptyKeyword = 159;
+    const EvalKeyword = 160;
+    const ExitKeyword = 161;
+    const DieKeyword = 162;
+    const IsSetKeyword = 163;
+    const PrintKeyword = 164;
+
+    // anonymous function creation expression
+    const FnKeyword = 165;
+
+    // begin_statement
+    const FunctionKeyword = 166;
+    const StaticKeyword = 167;
+
+    // end_statement
+
+    // end_expression
+
+    // end_keyword
+
+
+    // begin_reserved
+    const TrueReservedWord = 201;
+    const FalseReservedWord = 202;
+    const NullReservedWord = 203;
+
+    // begin_parameter_type_declaration
+    const IntReservedWord = 204;
+    const FloatReservedWord = 205;
+    const BoolReservedWord = 206;
+    const StringReservedWord = 207;
+    const ObjectReservedWord = 208;
+
+    // end_parameter_type_declaration
+    const BinaryReservedWord = 209;
+    const IntegerReservedWord = 210;
+    const DoubleReservedWord = 211;
+    const BooleanReservedWord = 212;
+    const RealReservedWord = 213;
+    const VoidReservedWord = 214;
+
+    // end_reserved
+
+    // end_name_or_keyword_or_reserved
+
+    // begin_statement
+    const OpenBraceToken = 215;
+    const SemicolonToken = 216;
+
+    // end_statement
+    const CloseBracketToken = 217;
+    const CloseParenToken = 218;
+    const CloseBraceToken = 219;
+    const DotToken = 220;
+    const ArrowToken = 221;
+    const AsteriskAsteriskToken = 222;
+    const AsteriskToken = 223;
+    const SlashToken = 224;
+    const PercentToken = 225;
+    const LessThanLessThanToken = 226;
+    const GreaterThanGreaterThanToken = 227;
+    const LessThanToken = 228;
+    const GreaterThanToken = 229;
+    const LessThanEqualsToken = 230;
+    const GreaterThanEqualsToken = 231;
+    const EqualsEqualsToken = 232;
+    const EqualsEqualsEqualsToken = 233;
+    const ExclamationEqualsToken = 234;
+    const ExclamationEqualsEqualsToken = 235;
+    const CaretToken = 236;
+    const BarToken = 237;
+    const AmpersandToken = 238;
+    const AmpersandAmpersandToken = 239;
+    const BarBarToken = 240;
+    const ColonToken = 241;
+    const EqualsToken = 242;
+    const AsteriskAsteriskEqualsToken = 243;
+    const AsteriskEqualsToken = 244;
+    const SlashEqualsToken = 245;
+    const PercentEqualsToken = 246;
+    const PlusEqualsToken = 247;
+    const MinusEqualsToken = 248;
+    const DotEqualsToken = 249;
+    const LessThanLessThanEqualsToken = 250;
+    const GreaterThanGreaterThanEqualsToken = 251;
+    const AmpersandEqualsToken = 252;
+    const CaretEqualsToken = 253;
+    const BarEqualsToken = 254;
+    const CommaToken = 255;
+    const QuestionQuestionToken = 256;
+    const LessThanEqualsGreaterThanToken = 257;
+    const DotDotDotToken = 258;
+    const ColonColonToken = 259;
+    const DoubleArrowToken = 260;
+    const LessThanGreaterThanToken = 261;
+    const QuestionToken = 262;
+    const QuestionQuestionEqualsToken = 263;
+
+    // begin_expression
+
+    // unary op expression
+    const PlusToken = 264;
+    const MinusToken = 265;
+    const TildeToken = 266;
+    const ExclamationToken = 267;
+
+    // error control expression
+    const AtSymbolToken = 268;
+
+    // prefix increment expression
+    const PlusPlusToken = 269;
+
+    // prefix decrement expression
+    const MinusMinusToken = 270;
+    const OpenBracketToken = 271;
+    const OpenParenToken = 272;
+    const DollarToken = 273;
+    const BackslashToken = 274;
+
+    // literal
+    const DecimalLiteralToken = 275;
+    const OctalLiteralToken = 276;
+    const HexadecimalLiteralToken = 277;
+    const BinaryLiteralToken = 278;
+    const FloatingLiteralToken = 279;
+    const InvalidOctalLiteralToken = 280;
+    const InvalidHexadecimalLiteral = 281;
+    const InvalidBinaryLiteral = 282;
+    const StringLiteralToken = 283;
+    const SingleQuoteToken = 284;
+    const DoubleQuoteToken = 285;
+    const HeredocStart = 286;
+    const BacktickToken = 287;
+
+    // end_expression
+
+
+    const ScriptSectionStartTag = 317;
+
+    // begin_statement
+    const ScriptSectionEndTag = 318;
+
+    // end_statement
+    const ScriptSectionStartWithEchoTag = 319;
 
     // TODO how to handle incremental parsing w/ this?
-    const ScriptSectionPrependedText = 325;
-    const VoidReservedWord = 326;
-    const FalseReservedWord = 327;
+    const ScriptSectionPrependedText = 320;
+    const MemberName = 321;
+    const Expression = 322;
+    const ReturnType = 323;
+    const InlineHtml = 324;
+    const PropertyType = 325;
 
-    const MemberName = 328;
-    const Expression = 329;
+    // DollarOpenCurly
 
-    const BinaryReservedWord = 330; // TODO better way
-    const BooleanReservedWord = 331;
-    const DoubleReservedWord = 332;
-    const IntegerReservedWord = 333;
-    const ObjectReservedWord = 334;
-    const RealReservedWord = 335;
-    const ReturnType = 336;
-    const InlineHtml = 337;
-    const PropertyType = 338;
-
-//    const DollarOpenCurly = 339;
     const EncapsedAndWhitespace = 400;
-    const SingleQuoteToken = 401;
-    const DoubleQuoteToken = 402;
-    const DollarOpenBraceToken = 403;
-    const OpenBraceDollarToken = 404;
-    const CastToken = 405;
-    const HeredocStart = 406;
-    const HeredocEnd = 407;
-    const StringVarname = 408;
-    const UnsetCastToken = 409;
-    const StringCastToken = 410;
-    const ObjectCastToken = 411;
-    const IntCastToken = 412;
-    const DoubleCastToken = 413;
-    const BoolCastToken = 414;
-    const ArrayCastToken = 415;
-    const IntegerLiteralToken = 416;
-    const CommentToken = 417;
-    const DocCommentToken = 418;
+    const DollarOpenBraceToken = 401;
+    const OpenBraceDollarToken = 402;
+    const CastToken = 403;
+    const HeredocEnd = 404;
+    const StringVarname = 405;
+
+    // begin_cast
+    const UnsetCastToken = 406;
+    const StringCastToken = 407;
+    const ObjectCastToken = 408;
+    const IntCastToken = 409;
+    const DoubleCastToken = 410;
+    const BoolCastToken = 411;
+    const ArrayCastToken = 412;
+
+    // end_cast
+    const IntegerLiteralToken = 413;
+    const CommentToken = 414;
+    const DocCommentToken = 415;
 
     // TODO type annotations - PHP7
+
+    public static function isExpression(int $tokenKind): bool
+    {
+        return (2 === $tokenKind) || (147 < $tokenKind && $tokenKind < 201) || (263 < $tokenKind && $tokenKind < 317);
+    }
+
+    public static function isNameOrKeywordOrReserved(int $tokenKind): bool
+    {
+        return 5 < $tokenKind && $tokenKind < 215;
+    }
+
+    public static function isKeyword(int $tokenKind): bool
+    {
+        return 6 < $tokenKind && $tokenKind < 201;
+    }
+
+    public static function isParameterTypeDeclaration(int $tokenKind): bool
+    {
+        return (101 < $tokenKind && $tokenKind < 104) || (203 < $tokenKind && $tokenKind < 209);
+    }
+
+    public static function isStatement(int $tokenKind): bool
+    {
+        return (103 < $tokenKind && $tokenKind < 125) || (165 < $tokenKind && $tokenKind < 201) || (214 < $tokenKind && $tokenKind < 217) || (318 === $tokenKind);
+    }
+
+    public static function isReserved(int $tokenKind): bool
+    {
+        return 167 < $tokenKind && $tokenKind < 215;
+    }
+
+    public static function isCast(int $tokenKind): bool
+    {
+        return 405 < $tokenKind && $tokenKind < 413;
+    }
 }

--- a/src/TokenKind.php
+++ b/src/TokenKind.php
@@ -282,7 +282,7 @@ class TokenKind {
 
     public static function isExpression(int $tokenKind): bool
     {
-        return (2 === $tokenKind) || (147 < $tokenKind && $tokenKind < 201) || (263 < $tokenKind && $tokenKind < 317);
+        return (2 === $tokenKind) || (147 < $tokenKind && $tokenKind < 201) ||(263 < $tokenKind && $tokenKind < 317);
     }
 
     public static function isNameOrKeywordOrReserved(int $tokenKind): bool

--- a/tests/cases/tokens/TokenTest.php
+++ b/tests/cases/tokens/TokenTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use Microsoft\PhpParser\Token;
+use Microsoft\PhpParser\TokenKind;
+use Microsoft\PhpParser\TokenStringMaps;
+use PHPUnit\Framework\TestCase;
+
+class TokenTest extends TestCase
+{
+
+    private function doMatch(array $expected, callable $isAMatch)
+    {
+        $expr = [];
+        foreach ($this->getConstants() as $kind) {
+            if ($isAMatch($kind)) {
+                $expr[] = $kind;
+            }
+        }
+        sort($expected);
+        sort($expr);
+        $this->assertEquals($expected, $expr);
+    }
+
+    public function testIsReserved()
+    {
+        $reserved = array_values(TokenStringMaps::RESERVED_WORDS);
+        $this->doMatch($reserved, function(int $kind){
+            return TokenKind::isReserved($kind);
+        });
+    }
+
+    public function testIsKeyword()
+    {
+        $keywords = array_values(TokenStringMaps::KEYWORDS);
+
+        $this->doMatch($keywords, function(int $kind){
+            return TokenKind::isKeyword($kind);
+        });
+    }
+
+    public function testIsNameOrKeywordOrReserved()
+    {
+        $tokenKinds = array_merge([TokenKind::Name], TokenStringMaps::KEYWORDS, TokenStringMaps::RESERVED_WORDS);
+        $this->doMatch(array_values($tokenKinds), function(int $kind){
+            return TokenKind::isNameOrKeywordOrReserved($kind);
+        });
+    }
+
+    public function testIsNameOrStaticOrReservedWord()
+    {
+        $tokenKinds = array_merge([TokenKind::Name, TokenKind::StaticKeyword], TokenStringMaps::RESERVED_WORDS);
+
+        foreach ($tokenKinds as $kind) {
+            $this->assertTrue(TokenKind::StaticKeyword === $kind || TokenKind::Name === $kind || TokenKind::isReserved($kind),
+                    "{$this->getTokenName($kind)} should be a name, static or a reserved word.");
+        }
+    }
+
+    public function testIsParameterType()
+    {
+        $tokenKinds = [
+            TokenKind::ArrayKeyword,
+            TokenKind::CallableKeyword,
+            TokenKind::BoolReservedWord,
+            TokenKind::FloatReservedWord,
+            TokenKind::IntReservedWord,
+            TokenKind::StringReservedWord,
+            TokenKind::ObjectReservedWord
+        ];
+
+        foreach ($tokenKinds as $kind) {
+            $this->assertTrue(TokenKind::isParameterTypeDeclaration($kind),
+                    "{$this->getTokenName($kind)} should be a parameter type.");
+        }
+    }
+
+    public function testIsReturnTypeDeclaration()
+    {
+         $tokenKinds = [
+            TokenKind::ArrayKeyword,
+            TokenKind::CallableKeyword,
+            TokenKind::BoolReservedWord,
+            TokenKind::FloatReservedWord,
+            TokenKind::IntReservedWord,
+            TokenKind::StringReservedWord,
+            TokenKind::ObjectReservedWord,
+            TokenKind::VoidReservedWord,
+        ];
+
+        foreach ($tokenKinds as $kind) {
+            $this->assertTrue(TokenKind::VoidReservedWord === $kind || TokenKind::isParameterTypeDeclaration($kind),
+                    "{$this->getTokenName($kind)} should be a return type");
+        }
+    }
+
+    private function getTokenName(int $kind): string
+    {
+        return Token::getTokenKindNameFromValue($kind) . " ($kind)";
+    }
+
+    private function getConstants(): array
+    {
+        return (new ReflectionClass(TokenKind::class))->getConstants();
+    }
+}

--- a/tools/GenerateTokens.php
+++ b/tools/GenerateTokens.php
@@ -1,0 +1,17 @@
+<?php
+
+use Microsoft\PhpParser\Token\Compiler;
+use Microsoft\PhpParser\Token\TokenCompiler;
+
+require __DIR__ . "/../vendor/autoload.php";
+require __DIR__ . "/tokens.php";
+
+
+$tokenCompiler = new TokenCompiler(new Compiler());
+
+$file = __DIR__ . "/../src/TokenKind.php";
+$data = utf8_encode($tokenCompiler->compile($tokens));
+
+file_put_contents($file, $data);
+echo $data;
+

--- a/tools/tokens.php
+++ b/tools/tokens.php
@@ -121,12 +121,12 @@ $tokens = [
     "comment anonymous function creation expression",
 
     "FnKeyword",
-    
+
     "begin_statement",
-    
+
     "FunctionKeyword",
     "StaticKeyword",
-    
+
     "end_statement",
 
     "end_expression",

--- a/tools/tokens.php
+++ b/tools/tokens.php
@@ -1,0 +1,324 @@
+<?php
+
+
+$tokens = [
+
+    "Unknown",
+    "EndOfFileToken",
+
+    "begin_expression",
+
+    "VariableName",
+
+    "end_expression",
+
+    "SkippedToken",
+    "MissingToken",
+    "QualifiedName",
+
+    "begin_name_or_keyword_or_reserved",
+
+    "Name",
+
+    "jump 100",
+
+    "begin_keyword",
+
+    "AbstractKeyword",
+    "AndKeyword",
+
+    "begin_parameter_type_declaration",
+
+    "ArrayKeyword",
+    "CallableKeyword",
+
+    "end_parameter_type_declaration",
+
+    "begin_statement",
+
+    "IfKeyword",
+    "SwitchKeyword",
+    "WhileKeyword",
+    "DoKeyword",
+    "ForKeyword",
+    "ForeachKeyword",
+    "GotoKeyword",
+    "ContinueKeyword",
+    "BreakKeyword",
+    "ReturnKeyword",
+    "ThrowKeyword",
+    "TryKeyword",
+    "DeclareKeyword",
+    "ConstKeyword",
+    "ClassKeyword",
+    "FinalKeyword",
+    "InterfaceKeyword",
+    "TraitKeyword",
+    "NamespaceKeyword",
+    "UseKeyword",
+    "GlobalKeyword",
+
+    "end_statement",
+
+    "AsKeyword",
+    "CaseKeyword",
+    "CatchKeyword",
+    "DefaultKeyword",
+    "ElseKeyword",
+    "ElseIfKeyword",
+    "EndDeclareKeyword",
+    "EndForKeyword",
+    "EndForEachKeyword",
+    "EndIfKeyword",
+    "EndSwitchKeyword",
+    "EndWhileKeyword",
+    "ExtendsKeyword",
+    "FinallyKeyword",
+    "ImplementsKeyword",
+    "InstanceOfKeyword",
+    "InsteadOfKeyword",
+    "OrKeyword",
+    "PrivateKeyword",
+    "ProtectedKeyword",
+    "PublicKeyword",
+    "VarKeyword",
+    "XorKeyword",
+
+    "begin_expression",
+
+    "comment script inclusion expression",
+
+    "RequireKeyword",
+    "RequireOnceKeyword",
+    "IncludeKeyword",
+    "IncludeOnceKeyword",
+
+    "comment yield expression",
+
+    "YieldKeyword",
+    "YieldFromKeyword",
+
+    "comment object creation expression",
+
+    "CloneKeyword",
+    "NewKeyword",
+
+    "comment intrinsic constructor",
+
+    "EchoKeyword",
+    "ListKeyword",
+    "UnsetKeyword",
+
+    "comment intrinsic operator",
+
+    "EmptyKeyword",
+    "EvalKeyword",
+    "ExitKeyword",
+    "DieKeyword",
+    "IsSetKeyword",
+    "PrintKeyword",
+
+    "comment anonymous function creation expression",
+
+    "FnKeyword",
+    
+    "begin_statement",
+    
+    "FunctionKeyword",
+    "StaticKeyword",
+    
+    "end_statement",
+
+    "end_expression",
+
+    "end_keyword",
+
+    "jump 201",
+
+    // RESERVED WORDS
+
+    "begin_reserved",
+
+
+    "TrueReservedWord",
+    "FalseReservedWord",
+    "NullReservedWord",
+
+    "begin_parameter_type_declaration",
+
+    "IntReservedWord",
+    "FloatReservedWord",
+    "BoolReservedWord",
+    "StringReservedWord",
+    "ObjectReservedWord",
+
+    "end_parameter_type_declaration",
+
+    "BinaryReservedWord", // TODO bet",
+    "IntegerReservedWord",
+    "DoubleReservedWord",
+    "BooleanReservedWord",
+    "RealReservedWord",
+    "VoidReservedWord",
+
+    "end_reserved",
+
+    "end_name_or_keyword_or_reserved",
+
+    "begin_statement",
+
+    "OpenBraceToken",
+    "SemicolonToken",
+
+    "end_statement",
+
+    "CloseBracketToken",
+    "CloseParenToken",
+    "CloseBraceToken",
+    "DotToken",
+    "ArrowToken",
+    "AsteriskAsteriskToken",
+    "AsteriskToken",
+    "SlashToken",
+    "PercentToken",
+    "LessThanLessThanToken",
+    "GreaterThanGreaterThanToken",
+    "LessThanToken",
+    "GreaterThanToken",
+    "LessThanEqualsToken",
+    "GreaterThanEqualsToken",
+    "EqualsEqualsToken",
+    "EqualsEqualsEqualsToken",
+    "ExclamationEqualsToken",
+    "ExclamationEqualsEqualsToken",
+    "CaretToken",
+    "BarToken",
+    "AmpersandToken",
+    "AmpersandAmpersandToken",
+    "BarBarToken",
+    "ColonToken",
+    "EqualsToken",
+    "AsteriskAsteriskEqualsToken",
+    "AsteriskEqualsToken",
+    "SlashEqualsToken",
+    "PercentEqualsToken",
+    "PlusEqualsToken",
+    "MinusEqualsToken",
+    "DotEqualsToken",
+    "LessThanLessThanEqualsToken",
+    "GreaterThanGreaterThanEqualsToken",
+    "AmpersandEqualsToken",
+    "CaretEqualsToken",
+    "BarEqualsToken",
+    "CommaToken",
+    "QuestionQuestionToken",
+    "LessThanEqualsGreaterThanToken",
+    "DotDotDotToken",
+    "ColonColonToken",
+    "DoubleArrowToken", // TODO missing from spec
+    "LessThanGreaterThanToken", // TODO missing from spec
+    "QuestionToken",
+    "QuestionQuestionEqualsToken",
+
+    "begin_expression",
+
+    "comment unary op expression",
+
+    "PlusToken",
+    "MinusToken",
+    "TildeToken",
+    "ExclamationToken",
+
+    "comment error control expression",
+
+    "AtSymbolToken",
+
+    "comment prefix increment expression",
+
+    "PlusPlusToken",
+
+    "comment prefix decrement expression",
+
+    "MinusMinusToken",
+
+    "OpenBracketToken",
+    "OpenParenToken",
+
+    "DollarToken",
+    "BackslashToken",
+
+    "comment literal",
+
+    "DecimalLiteralToken",
+    "OctalLiteralToken",
+    "HexadecimalLiteralToken",
+    "BinaryLiteralToken",
+    "FloatingLiteralToken",
+    "InvalidOctalLiteralToken",
+    "InvalidHexadecimalLiteral",
+    "InvalidBinaryLiteral",
+    "StringLiteralToken",
+
+    "SingleQuoteToken",
+    "DoubleQuoteToken",
+    "HeredocStart",
+    "BacktickToken",
+
+    "end_expression",
+
+    "jump 301",
+
+    "jump 317",
+
+
+
+    "ScriptSectionStartTag",
+
+    "begin_statement",
+
+    "ScriptSectionEndTag",
+
+    "end_statement",
+
+    "ScriptSectionStartWithEchoTag",
+
+
+    "TODO how to handle incremental parsing w/ this?",
+
+    "ScriptSectionPrependedText",
+
+    "MemberName",
+    "Expression",
+
+    "ReturnType",
+    "InlineHtml",
+    "PropertyType",
+
+    "comment DollarOpenCurly",
+
+    "jump 400",
+
+    "EncapsedAndWhitespace",
+    "DollarOpenBraceToken",
+    "OpenBraceDollarToken",
+    "CastToken",
+    "HeredocEnd",
+    "StringVarname",
+
+    "begin_cast",
+
+    "UnsetCastToken",
+    "StringCastToken",
+    "ObjectCastToken",
+    "IntCastToken",
+    "DoubleCastToken",
+    "BoolCastToken",
+    "ArrayCastToken",
+
+   "end_cast",
+
+    "IntegerLiteralToken",
+    "CommentToken",
+    "DocCommentToken",
+    "TODO type annotations - PHP7"
+];


### PR DESCRIPTION
Hi,
Can you check if this changes may help?
In the Go [go/token](https://github.com/golang/go/blob/master/src/go/token/token.go) package. Tokens are arranged by groups, "keywords", "literal", "operators" and this tokens are delimited by constants like "begin_keyword" ... "end_keyword", so any token between those constants are keywords. So,  to check if a token is keyword you don't have to iterate every token considered as a "keyword" and only check the method: token.isKeyword() => begin_keyword < tok && tok < end_keyword.

So, I decided to use this approach to organize the tokens of the parser and create helper functions to decide if a token is a keyword, the start of an expression, a parameter type, or anything that may help us in the parser.
using the script in tools/GenerateTokens.php which use the file tokens.php in the same folder, we can generate the TokenKind.php file if necesary. With this change methods like isStatementStart (9 lines) or isExpressionStart(10 lines) looks smaller in the parser and things like checking for in_array($token->kind, $this->keywordTokens) can be replaced with $token->isReserved() where isReserved only checks that the token is in the range of the keywords.
I created a TokensTest and I ran all tests before and after. It looks like that at least I didn't break anything.

I would appreciate any comment on this.
Thank you!

