### PR TITLE
Remove TODO for trailing comma in parameter list

### DIFF
--- a/tests/cases/parser/functions13.php
+++ b/tests/cases/parser/functions13.php
@@ -1,5 +1,5 @@
 <?php
-// TODO add error checking for this case
+// Allowed in php 8: https://wiki.php.net/rfc/trailing_comma_in_parameter_list
 function foobar ($a, MyName ...$b,) {
 
 }


### PR DESCRIPTION
https://wiki.php.net/rfc/trailing_comma_in_parameter_list
is likely to pass, and makes that obsolete