### PR TITLE
Support parsing php 8.0's non-capturing catch statement

### DIFF
--- a/src/Node/CatchClause.php
+++ b/src/Node/CatchClause.php
@@ -24,7 +24,7 @@ class CatchClause extends Node {
      * TODO: In the next backwards incompatible release, replace qualifiedName with qualifiedNameList?
      */
     public $otherQualifiedNameList;
-    /** @var Token */
+    /** @var Token|null */
     public $variableName;
     /** @var Token */
     public $closeParen;

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -2249,7 +2249,7 @@ class Parser {
         $qualifiedNameList = $this->parseQualifiedNameCatchList($catchClause)->children ?? [];
         $catchClause->qualifiedName = $qualifiedNameList[0] ?? null; // TODO generate missing token or error if null
         $catchClause->otherQualifiedNameList = array_slice($qualifiedNameList, 1);  // TODO: Generate error if the name list has missing tokens
-        $catchClause->variableName = $this->eat1(TokenKind::VariableName);
+        $catchClause->variableName = $this->eatOptional1(TokenKind::VariableName);
         $catchClause->closeParen = $this->eat1(TokenKind::CloseParenToken);
         $catchClause->compoundStatement = $this->parseCompoundStatement($catchClause);
 

--- a/tests/cases/parser/tryStatement10.php.diag
+++ b/tests/cases/parser/tryStatement10.php.diag
@@ -1,8 +1,1 @@
-[
-    {
-        "kind": 0,
-        "message": "'VariableName' expected.",
-        "start": 22,
-        "length": 0
-    }
-]
+[]

--- a/tests/cases/parser/tryStatement10.php.tree
+++ b/tests/cases/parser/tryStatement10.php.tree
@@ -43,11 +43,7 @@
                                 },
                                 "qualifiedName": null,
                                 "otherQualifiedNameList": [],
-                                "variableName": {
-                                    "error": "MissingToken",
-                                    "kind": "VariableName",
-                                    "textLength": 0
-                                },
+                                "variableName": null,
                                 "closeParen": {
                                     "kind": "CloseParenToken",
                                     "textLength": 1

--- a/tests/cases/parser/tryStatement13.php.diag
+++ b/tests/cases/parser/tryStatement13.php.diag
@@ -1,12 +1,6 @@
 [
     {
         "kind": 0,
-        "message": "'VariableName' expected.",
-        "start": 169,
-        "length": 0
-    },
-    {
-        "kind": 0,
         "message": "')' expected.",
         "start": 169,
         "length": 0

--- a/tests/cases/parser/tryStatement13.php.tree
+++ b/tests/cases/parser/tryStatement13.php.tree
@@ -43,11 +43,7 @@
                                 },
                                 "qualifiedName": null,
                                 "otherQualifiedNameList": [],
-                                "variableName": {
-                                    "error": "MissingToken",
-                                    "kind": "VariableName",
-                                    "textLength": 0
-                                },
+                                "variableName": null,
                                 "closeParen": {
                                     "error": "MissingToken",
                                     "kind": "CloseParenToken",

--- a/tests/cases/parser/tryStatement8.php.diag
+++ b/tests/cases/parser/tryStatement8.php.diag
@@ -7,12 +7,6 @@
     },
     {
         "kind": 0,
-        "message": "'VariableName' expected.",
-        "start": 21,
-        "length": 0
-    },
-    {
-        "kind": 0,
         "message": "')' expected.",
         "start": 21,
         "length": 0

--- a/tests/cases/parser/tryStatement8.php.tree
+++ b/tests/cases/parser/tryStatement8.php.tree
@@ -44,11 +44,7 @@
                                 },
                                 "qualifiedName": null,
                                 "otherQualifiedNameList": [],
-                                "variableName": {
-                                    "error": "MissingToken",
-                                    "kind": "VariableName",
-                                    "textLength": 0
-                                },
+                                "variableName": null,
                                 "closeParen": {
                                     "error": "MissingToken",
                                     "kind": "CloseParenToken",

--- a/tests/cases/parser/tryStatement9.php.diag
+++ b/tests/cases/parser/tryStatement9.php.diag
@@ -1,8 +1,1 @@
-[
-    {
-        "kind": 0,
-        "message": "'VariableName' expected.",
-        "start": 27,
-        "length": 0
-    }
-]
+[]

--- a/tests/cases/parser/tryStatement9.php.tree
+++ b/tests/cases/parser/tryStatement9.php.tree
@@ -54,11 +54,7 @@
                                     }
                                 },
                                 "otherQualifiedNameList": [],
-                                "variableName": {
-                                    "error": "MissingToken",
-                                    "kind": "VariableName",
-                                    "textLength": 0
-                                },
+                                "variableName": null,
                                 "closeParen": {
                                     "kind": "CloseParenToken",
                                     "textLength": 1


### PR DESCRIPTION
https://wiki.php.net/rfc/non-capturing_catches was merged into php
8.0-dev.