### PR TITLE
Warn about missing use variable

### DIFF
--- a/src/Node/AnonymousFunctionUseClause.php
+++ b/src/Node/AnonymousFunctionUseClause.php
@@ -6,6 +6,7 @@
 
 namespace Microsoft\PhpParser\Node;
 
+use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\DelimitedList\UseVariableNameList;
 use Microsoft\PhpParser\Token;
@@ -17,7 +18,7 @@ class AnonymousFunctionUseClause extends Node {
     /** @var Token */
     public $openParen;
 
-    /** @var UseVariableNameList */
+    /** @var UseVariableNameList|MissingToken */
     public $useVariableNameList;
 
     /** @var Token */

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -3566,7 +3566,7 @@ class Parser {
                 return $useVariableName;
             },
             $anonymousFunctionUseClause
-        );
+        ) ?: (new MissingToken(TokenKind::VariableName, $this->token->fullStart));
         $anonymousFunctionUseClause->closeParen = $this->eat1(TokenKind::CloseParenToken);
 
         return $anonymousFunctionUseClause;

--- a/tests/cases/parser/anonymousFunctionCreationExpression11.php
+++ b/tests/cases/parser/anonymousFunctionCreationExpression11.php
@@ -1,0 +1,2 @@
+<?php
+function () use() {};

--- a/tests/cases/parser/anonymousFunctionCreationExpression11.php.diag
+++ b/tests/cases/parser/anonymousFunctionCreationExpression11.php.diag
@@ -1,0 +1,8 @@
+[
+    {
+        "kind": 0,
+        "message": "'VariableName' expected.",
+        "start": 22,
+        "length": 0
+    }
+]

--- a/tests/cases/parser/anonymousFunctionCreationExpression11.php.tree
+++ b/tests/cases/parser/anonymousFunctionCreationExpression11.php.tree
@@ -1,0 +1,86 @@
+{
+    "SourceFileNode": {
+        "statementList": [
+            {
+                "InlineHtml": {
+                    "scriptSectionEndTag": null,
+                    "text": null,
+                    "scriptSectionStartTag": {
+                        "kind": "ScriptSectionStartTag",
+                        "textLength": 6
+                    }
+                }
+            },
+            {
+                "ExpressionStatement": {
+                    "expression": {
+                        "AnonymousFunctionCreationExpression": {
+                            "staticModifier": null,
+                            "functionKeyword": {
+                                "kind": "FunctionKeyword",
+                                "textLength": 8
+                            },
+                            "byRefToken": null,
+                            "name": null,
+                            "openParen": {
+                                "kind": "OpenParenToken",
+                                "textLength": 1
+                            },
+                            "parameters": null,
+                            "closeParen": {
+                                "kind": "CloseParenToken",
+                                "textLength": 1
+                            },
+                            "anonymousFunctionUseClause": {
+                                "AnonymousFunctionUseClause": {
+                                    "useKeyword": {
+                                        "kind": "UseKeyword",
+                                        "textLength": 3
+                                    },
+                                    "openParen": {
+                                        "kind": "OpenParenToken",
+                                        "textLength": 1
+                                    },
+                                    "useVariableNameList": {
+                                        "error": "MissingToken",
+                                        "kind": "VariableName",
+                                        "textLength": 0
+                                    },
+                                    "closeParen": {
+                                        "kind": "CloseParenToken",
+                                        "textLength": 1
+                                    }
+                                }
+                            },
+                            "colonToken": null,
+                            "questionToken": null,
+                            "returnType": null,
+                            "otherReturnTypes": null,
+                            "compoundStatementOrSemicolon": {
+                                "CompoundStatementNode": {
+                                    "openBrace": {
+                                        "kind": "OpenBraceToken",
+                                        "textLength": 1
+                                    },
+                                    "statements": [],
+                                    "closeBrace": {
+                                        "kind": "CloseBraceToken",
+                                        "textLength": 1
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "semicolon": {
+                        "kind": "SemicolonToken",
+                        "textLength": 1
+                    }
+                }
+            }
+        ],
+        "endOfFileToken": {
+            "kind": "EndOfFileToken",
+            "textLength": 0
+        }
+    }
+}


### PR DESCRIPTION
Closures require 1 or more variables if there is a `use` clause.

```
php > function() use(){};
Parse error: syntax error, unexpected ')', expecting '&' or variable
(T_VARIABLE) in php shell code on line 1
```