### PR TITLE
Support testing with phpunit 7 as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": ">=7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.4"
+        "phpunit/phpunit": "^6.4|^7.5.20"
     },
     "license": "MIT",
     "authors": [

--- a/tests/CallbackTestListener.php
+++ b/tests/CallbackTestListener.php
@@ -1,0 +1,36 @@
+<?php
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+use PHPUnit\Framework\Test;
+use PHPUnit\Framework\TestListener;
+use PHPUnit\Framework\TestListenerDefaultImplementation;
+use PHPUnit\Framework\AssertionFailedError;
+
+if (PHP_VERSION_ID >= 70100) {
+    // PHPUnit 7 requires a return type of void, which is impossible in php 7.0
+    class CallbackTestListener implements TestListener {
+        private $cb;
+        public function __construct(Closure $cb) {
+            $this->cb = $cb;
+        }
+        use TestListenerDefaultImplementation;
+        // php 7.1 does not support param type widening.
+        function addFailure(Test $test, AssertionFailedError $e, float $time): void {
+            ($this->cb)($test);
+        }
+    }
+} else {
+    class CallbackTestListener implements TestListener {
+        private $cb;
+        public function __construct(Closure $cb) {
+            $this->cb = $cb;
+        }
+        use TestListenerDefaultImplementation;
+        function addFailure(Test $test, AssertionFailedError $e, $time) {
+            ($this->cb)($test);
+        }
+    }
+}

--- a/tests/LexicalGrammarTest.php
+++ b/tests/LexicalGrammarTest.php
@@ -11,6 +11,8 @@ use PHPUnit\Framework\TestResult;
 use PHPUnit\Framework\BaseTestListener;
 use PHPUnit\Framework\AssertionFailedError;
 
+require_once __DIR__ . '/CallbackTestListener.php';
+
 class LexicalGrammarTest extends TestCase {
     const FILE_PATTERN = __DIR__ . "/cases/lexical/*";
     public function run(TestResult $result = null) : TestResult {
@@ -19,14 +21,11 @@ class LexicalGrammarTest extends TestCase {
             exec("git -C " . dirname(self::FILE_PATTERN) . " checkout *.php.tokens");
         }
 
-        $result->addListener(new class() extends BaseTestListener {
-            function addFailure(Test $test, AssertionFailedError $e, $time) {
-                if (isset($test->expectedTokensFile) && isset($test->tokens)) {
-                    file_put_contents($test->expectedTokensFile, str_replace("\r\n", "\n", $test->tokens));
-                }
-                parent::addFailure($test, $e, $time);
+        $result->addListener(new CallbackTestListener(function (Test $test) {
+            if (isset($test->expectedTokensFile) && isset($test->tokens)) {
+                file_put_contents($test->expectedTokensFile, str_replace("\r\n", "\n", $test->tokens));
             }
-        });
+        }));
 
         $result = parent::run($result);
         return $result;


### PR DESCRIPTION
Prepare for testing with PHP 8.0. This works well enough with `--ignore-platform-reqs`

An alternative would be to drop support for php 7.0

The call to parent::addFailure was a no-op.