### PR TITLE
Start running tests in travis with nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ php:
   - 7.2
   - 7.3
   - 7.4
+  # Should be changed to 8.0 once travis officially provides that label.
+  - nightly
 
 env:
   - VALIDATION=false
@@ -28,7 +30,12 @@ cache:
 
 before_script:
   - if [[ $STATIC_ANALYSIS = true ]]; then composer require phpstan/phpstan --no-update; fi
-  - composer install
+  - |
+    if php -r 'exit(PHP_MAJOR_VERSION < 8 ? 0 : 1);';
+      then composer install
+    else
+      composer install --ignore-platform-reqs
+    fi
   - set -e # Stop on first error.
   - phpenv config-rm xdebug.ini || true
   - if find . -name "*.php" -path "./src/*" -path "./experiments/*" -path "./tools/*" -path "./syntax-visualizer/server/src/*" -exec php -l {} 2>&1 \; | grep "syntax error, unexpected"; then exit 1; fi


### PR DESCRIPTION
Whenever Travis provides a stable 8.0 label, that can be switched to.
Currently, though, that's not available. 8.0snapshot could not be
installed when I tried.