### PR TITLE
Warn about #[] attribute groups of 0 length

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -757,7 +757,8 @@ class Parser {
         while ($attributeToken = $this->eatOptional1(TokenKind::AttributeToken)) {
             $attributeGroup = new AttributeGroup();
             $attributeGroup->startToken = $attributeToken;
-            $attributeGroup->attributes = $this->parseAttributeElementList($attributeGroup);
+            $attributeGroup->attributes = $this->parseAttributeElementList($attributeGroup)
+                ?: (new MissingToken(TokenKind::Name, $this->token->fullStart));
             $attributeGroup->endToken = $this->eat1(TokenKind::CloseBracketToken);
             $attributeGroup->parent = $parentNode;
             $attributeGroups[] = $attributeGroup;

--- a/tests/cases/parser80/attributes16.php.diag
+++ b/tests/cases/parser80/attributes16.php.diag
@@ -13,6 +13,12 @@
     },
     {
         "kind": 0,
+        "message": "'Name' expected.",
+        "start": 15,
+        "length": 0
+    },
+    {
+        "kind": 0,
         "message": "']' expected.",
         "start": 15,
         "length": 0

--- a/tests/cases/parser80/attributes16.php.tree
+++ b/tests/cases/parser80/attributes16.php.tree
@@ -40,7 +40,11 @@
                                                         "kind": "AttributeToken",
                                                         "textLength": 2
                                                     },
-                                                    "attributes": null,
+                                                    "attributes": {
+                                                        "error": "MissingToken",
+                                                        "kind": "Name",
+                                                        "textLength": 0
+                                                    },
                                                     "endToken": {
                                                         "error": "MissingToken",
                                                         "kind": "CloseBracketToken",

--- a/tests/cases/parser80/attributes17.php.diag
+++ b/tests/cases/parser80/attributes17.php.diag
@@ -13,6 +13,12 @@
     },
     {
         "kind": 0,
+        "message": "'Name' expected.",
+        "start": 18,
+        "length": 0
+    },
+    {
+        "kind": 0,
         "message": "']' expected.",
         "start": 18,
         "length": 0

--- a/tests/cases/parser80/attributes17.php.tree
+++ b/tests/cases/parser80/attributes17.php.tree
@@ -41,7 +41,11 @@
                                                         "kind": "AttributeToken",
                                                         "textLength": 2
                                                     },
-                                                    "attributes": null,
+                                                    "attributes": {
+                                                        "error": "MissingToken",
+                                                        "kind": "Name",
+                                                        "textLength": 0
+                                                    },
                                                     "endToken": {
                                                         "error": "MissingToken",
                                                         "kind": "CloseBracketToken",

--- a/tests/cases/parser80/attributes18.php.diag
+++ b/tests/cases/parser80/attributes18.php.diag
@@ -7,6 +7,12 @@
     },
     {
         "kind": 0,
+        "message": "'Name' expected.",
+        "start": 11,
+        "length": 0
+    },
+    {
+        "kind": 0,
         "message": "']' expected.",
         "start": 11,
         "length": 0

--- a/tests/cases/parser80/attributes18.php.tree
+++ b/tests/cases/parser80/attributes18.php.tree
@@ -40,7 +40,11 @@
                                                                 "kind": "AttributeToken",
                                                                 "textLength": 2
                                                             },
-                                                            "attributes": null,
+                                                            "attributes": {
+                                                                "error": "MissingToken",
+                                                                "kind": "Name",
+                                                                "textLength": 0
+                                                            },
                                                             "endToken": {
                                                                 "error": "MissingToken",
                                                                 "kind": "CloseBracketToken",

--- a/tests/cases/parser80/attributes19.php.diag
+++ b/tests/cases/parser80/attributes19.php.diag
@@ -1,0 +1,8 @@
+[
+    {
+        "kind": 0,
+        "message": "'Name' expected.",
+        "start": 8,
+        "length": 0
+    }
+]

--- a/tests/cases/parser80/attributes19.php.tree
+++ b/tests/cases/parser80/attributes19.php.tree
@@ -1,0 +1,67 @@
+{
+    "SourceFileNode": {
+        "statementList": [
+            {
+                "InlineHtml": {
+                    "scriptSectionEndTag": null,
+                    "text": null,
+                    "scriptSectionStartTag": {
+                        "kind": "ScriptSectionStartTag",
+                        "textLength": 6
+                    }
+                }
+            },
+            {
+                "ClassDeclaration": {
+                    "attributes": [
+                        {
+                            "AttributeGroup": {
+                                "startToken": {
+                                    "kind": "AttributeToken",
+                                    "textLength": 2
+                                },
+                                "attributes": {
+                                    "error": "MissingToken",
+                                    "kind": "Name",
+                                    "textLength": 0
+                                },
+                                "endToken": {
+                                    "kind": "CloseBracketToken",
+                                    "textLength": 1
+                                }
+                            }
+                        }
+                    ],
+                    "abstractOrFinalModifier": null,
+                    "classKeyword": {
+                        "kind": "ClassKeyword",
+                        "textLength": 5
+                    },
+                    "name": {
+                        "kind": "Name",
+                        "textLength": 1
+                    },
+                    "classBaseClause": null,
+                    "classInterfaceClause": null,
+                    "classMembers": {
+                        "ClassMembersNode": {
+                            "openBrace": {
+                                "kind": "OpenBraceToken",
+                                "textLength": 1
+                            },
+                            "classMemberDeclarations": [],
+                            "closeBrace": {
+                                "kind": "CloseBraceToken",
+                                "textLength": 1
+                            }
+                        }
+                    }
+                }
+            }
+        ],
+        "endOfFileToken": {
+            "kind": "EndOfFileToken",
+            "textLength": 0
+        }
+    }
+}


### PR DESCRIPTION
Each attribute group must have 1 or more elements.
The same approach is used for closure use element lists.

    php > #[] class X{}

    Parse error: syntax error, unexpected token "]" in php shell code
    on line 1