### PR TITLE
[Feature] Support the php 7.1 iterable type hint as a unique token kind

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -141,7 +141,8 @@ class Parser {
         $this->parameterTypeDeclarationTokens =
             [TokenKind::ArrayKeyword, TokenKind::CallableKeyword, TokenKind::BoolReservedWord,
             TokenKind::FloatReservedWord, TokenKind::IntReservedWord, TokenKind::StringReservedWord,
-            TokenKind::ObjectReservedWord, TokenKind::NullReservedWord, TokenKind::FalseReservedWord]; // TODO update spec
+            TokenKind::ObjectReservedWord, TokenKind::NullReservedWord, TokenKind::FalseReservedWord,
+            TokenKind::IterableKeyword]; // TODO update spec
         $this->returnTypeDeclarationTokens = \array_merge([TokenKind::VoidReservedWord, TokenKind::NullReservedWord, TokenKind::FalseReservedWord, TokenKind::StaticKeyword], $this->parameterTypeDeclarationTokens);
     }
 

--- a/src/TokenKind.php
+++ b/src/TokenKind.php
@@ -87,6 +87,7 @@ class TokenKind {
     const YieldFromKeyword = 167;
     const FnKeyword = 168;
     const MatchKeyword = 169;
+    const IterableKeyword = 170;
 
     const OpenBracketToken = 201;
     const CloseBracketToken = 202;

--- a/src/TokenStringMaps.php
+++ b/src/TokenStringMaps.php
@@ -103,7 +103,8 @@ class TokenStringMaps {
         "integer" => TokenKind::IntegerReservedWord,
         "object" => TokenKind::ObjectReservedWord,
         "real" => TokenKind::RealReservedWord,
-        "void" => TokenKind::VoidReservedWord
+        "void" => TokenKind::VoidReservedWord,
+        "iterable" => TokenKind::IterableKeyword,
     ];
 
     const OPERATORS_AND_PUNCTUATORS = array(

--- a/tests/cases/parser74/arrowFunctionUnionTypes.php.tree
+++ b/tests/cases/parser74/arrowFunctionUnionTypes.php.tree
@@ -241,16 +241,8 @@
                                                 "visibilityToken": null,
                                                 "questionToken": null,
                                                 "typeDeclaration": {
-                                                    "QualifiedName": {
-                                                        "globalSpecifier": null,
-                                                        "relativeSpecifier": null,
-                                                        "nameParts": [
-                                                            {
-                                                                "kind": "Name",
-                                                                "textLength": 8
-                                                            }
-                                                        ]
-                                                    }
+                                                    "kind": "IterableKeyword",
+                                                    "textLength": 8
                                                 },
                                                 "otherTypeDeclarations": {
                                                     "QualifiedNameList": {
@@ -406,16 +398,8 @@
                                                 "visibilityToken": null,
                                                 "questionToken": null,
                                                 "typeDeclaration": {
-                                                    "QualifiedName": {
-                                                        "globalSpecifier": null,
-                                                        "relativeSpecifier": null,
-                                                        "nameParts": [
-                                                            {
-                                                                "kind": "Name",
-                                                                "textLength": 8
-                                                            }
-                                                        ]
-                                                    }
+                                                    "kind": "IterableKeyword",
+                                                    "textLength": 8
                                                 },
                                                 "otherTypeDeclarations": {
                                                     "QualifiedNameList": {
@@ -589,16 +573,8 @@
                                             "textLength": 1
                                         },
                                         {
-                                            "QualifiedName": {
-                                                "globalSpecifier": null,
-                                                "relativeSpecifier": null,
-                                                "nameParts": [
-                                                    {
-                                                        "kind": "Name",
-                                                        "textLength": 8
-                                                    }
-                                                ]
-                                            }
+                                            "kind": "IterableKeyword",
+                                            "textLength": 8
                                         }
                                     ]
                                 }


### PR DESCRIPTION
Hi,

This PR implements the feature suggested in #191 

There already was a tests using `iterable`, for now I reused it.
If you want a dedicated test that's not a problem, I will simply need a few information:
* Should I remove the `iterable` type from the current `arrowFunctionUnionTypes.php` test so that it will not be impacted by the changes ?
* Where should I put the new test ? `tests/cases/parser71/iterableType.php` ?
* Is the example provided in the issue enough or do you have something else in mind ?