### PR TITLE
Error when calling getNamespaceDefinition on SourceFileNode

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -584,7 +584,7 @@ abstract class Node implements \JsonSerializable {
      * @return NamespaceDefinition|null
      */
     public function getNamespaceDefinition() {
-        $namespaceDefinition = $this instanceof NamespaceDefinition
+        $namespaceDefinition = ($this instanceof NamespaceDefinition || $this instanceof SourceFileNode)
             ? $this
             : $this->getFirstAncestor(NamespaceDefinition::class, SourceFileNode::class);
 


### PR DESCRIPTION
Hopefully fixes #255.

Adds an additional initial check for the source file node, after which we start searching in the ancestors.