### PR TITLE
Fix PHP 8.2 deprecation notices in tolerant-php-parser

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -2128,6 +2128,7 @@ class Parser {
             }
 
             if ($shouldOperatorTakePrecedenceOverUnary) {
+                /** @var UnaryOpExpression $unaryExpression */
                 $unaryExpression = $leftOperand;
                 $leftOperand = $unaryExpression->operand;
             }
@@ -2149,6 +2150,7 @@ class Parser {
 
             // Rebuild the unary expression if we deconstructed it earlier.
             if ($shouldOperatorTakePrecedenceOverUnary) {
+                /** @var UnaryOpExpression $unaryExpression */
                 $leftOperand->parent = $unaryExpression;
                 $unaryExpression->operand = $leftOperand;
                 $leftOperand = $unaryExpression;
@@ -2275,6 +2277,14 @@ class Parser {
         // InstanceOf has other remaining issues, but this heuristic is an improvement for many common cases such as `$x && $y = $z`
     ];
 
+    /**
+     * @param Token|Node $leftOperand
+     * @param Token $operatorToken
+     * @param Token|null $byRefToken
+     * @param Token|Node $rightOperand
+     * @param Node $parentNode
+     * @return BinaryExpression|AssignmentExpression
+     */
     private function makeBinaryExpression($leftOperand, $operatorToken, $byRefToken, $rightOperand, $parentNode) {
         $assignmentExpression = $operatorToken->kind === TokenKind::EqualsToken;
         if ($assignmentExpression || \array_key_exists($operatorToken->kind, self::KNOWN_ASSIGNMENT_TOKEN_SET)) {
@@ -2289,8 +2299,12 @@ class Parser {
         }
         $binaryExpression = $assignmentExpression ? new AssignmentExpression() : new BinaryExpression();
         $binaryExpression->parent = $parentNode;
-        $leftOperand->parent = $binaryExpression;
-        $rightOperand->parent = $binaryExpression;
+        if ($leftOperand instanceof Node) {
+            $leftOperand->parent = $binaryExpression;
+        }
+        if ($rightOperand instanceof Node) {
+            $rightOperand->parent = $binaryExpression;
+        }
         $binaryExpression->leftOperand = $leftOperand;
         $binaryExpression->operator = $operatorToken;
         if ($binaryExpression instanceof AssignmentExpression && isset($byRefToken)) {

--- a/tests/LexicalGrammarTest.php
+++ b/tests/LexicalGrammarTest.php
@@ -14,6 +14,8 @@ use PHPUnit\Framework\AssertionFailedError;
 require_once __DIR__ . '/CallbackTestListener.php';
 
 class LexicalGrammarTest extends TestCase {
+    private $expectedTokensFile;
+    private $tokens;
     const FILE_PATTERN = __DIR__ . "/cases/lexical/*";
     public function run(TestResult $result = null) : TestResult {
         if (!isset($GLOBALS["GIT_CHECKOUT_LEXER"])) {

--- a/tests/ParserGrammarTest.php
+++ b/tests/ParserGrammarTest.php
@@ -15,6 +15,10 @@ use PHPUnit\Framework\AssertionFailedError;
 require_once __DIR__ . '/CallbackTestListener.php';
 
 class ParserGrammarTest extends TestCase {
+    private $expectedTokensFile;
+    private $expectedDiagnosticsFile;
+    private $tokens;
+    private $diagnostics;
     public function run(TestResult $result = null) : TestResult {
         if (!isset($GLOBALS["GIT_CHECKOUT_PARSER"])) {
             $GLOBALS["GIT_CHECKOUT_PARSER"] = true;


### PR DESCRIPTION
https://wiki.php.net/rfc/deprecate_dynamic_properties
was approved and merged into php 8.2.

Dynamic (undeclared) properties will be forbidden without
`#[AllowDynamicProperties]` in the next major release (9.0).

A separate followup question would be whether to include
`#[AllowDynamicProperties]` on the Node class declaration
or to instead do something similar to nikic/php-parser and add a dedicated
attributes array property for any applications using this library to
track state on nodes.
(This isn't something I personally need, though. I haven't found any use cases in applications I've used before, largely because static analyzers I'm aware of use php-parser or php-ast for analysis.)

- https://github.com/microsoft/tolerant-php-parser/network/dependents?dependent_type=PACKAGE would be a place to start looking. php-language-server is not installable in php 8.x right now for unrelated reasons.