### PR TITLE
Remove a TODO that no longer applies in php 8.0

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1324,8 +1324,6 @@ class Parser {
                 case TokenKind::DollarOpenBraceToken:
                 case TokenKind::OpenBraceDollarToken:
                     $expression->children[] = $this->eat(TokenKind::DollarOpenBraceToken, TokenKind::OpenBraceDollarToken);
-                    // TODO: Reject ${var->prop} and ${(var->prop)} without rejecting ${var+otherVar}
-                    // Currently, this fails to reject ${var->prop} (because `var` has TokenKind::Name instead of StringVarname)
                     if ($this->getCurrentToken()->kind === TokenKind::StringVarname) {
                         $expression->children[] = $this->parseComplexDollarTemplateStringExpression($expression);
                     } else {


### PR DESCRIPTION
Any expression can be used as of 8.0 without an unexpected syntax error.

In encapsulated strings,
`"${a->prop}"` is equivalent to `"{${(a->prop)}}"` in php 8.0 and a
syntax error in previous php versions.

(Get the property `prop` of the global constant `a` (constants can be
objects in php 8.1), then get the variable with the name equal to that
string)

Related to #230 