### PR TITLE
Speed up running the framework validation test suite

### DIFF
--- a/tests/ParserFrameworkValidationTests.php
+++ b/tests/ParserFrameworkValidationTests.php
@@ -40,25 +40,33 @@ class ParserFrameworkValidationTests extends TestCase {
         $parser = new \Microsoft\PhpParser\Parser();
         $sourceFile = $parser->parseSourceFile($fileContents);
 
-        $directory = __DIR__ . "/output/$frameworkName/";
-        if (!file_exists($dir = __DIR__ . "/output")) {
-            mkdir($dir);
-        }
-        if (!file_exists($directory)) {
-            mkdir($directory);
-        }
-        $outFile = $directory . basename($testCaseFile);
-        file_put_contents($outFile, $fileContents);
-
-        foreach ($sourceFile->getDescendantNodesAndTokens() as $child) {
-            if ($child instanceof Token) {
-                $this->assertNotEquals(\Microsoft\PhpParser\TokenKind::Unknown, $child->kind, "input: $testCaseFile\r\nexpected: ");
-                $this->assertNotInstanceOf(\Microsoft\PhpParser\SkippedToken::class, $child, "input: $testCaseFile\r\nexpected: ");
-                $this->assertNotInstanceOf(\Microsoft\PhpParser\MissingToken::class, $child, "input: $testCaseFile\r\nexpected: ");
+        try {
+            foreach ($sourceFile->getDescendantNodesAndTokens() as $child) {
+                if ($child instanceof Token) {
+                    if (get_class($child) === Token::class && $child->kind !== \Microsoft\PhpParser\TokenKind::Unknown) {
+                        // NOTE: This parsing many tokens each from 10000+ files - the PHPUnit assert method calls are slow and
+                        // Without this optimization, the test suite takes 93 seconds.
+                        // With this optimization, the method takes 30 seconds.
+                        continue;
+                    }
+                    $this->assertNotEquals(\Microsoft\PhpParser\TokenKind::Unknown, $child->kind, "input: $testCaseFile\r\nexpected: ");
+                    $this->assertNotInstanceOf(\Microsoft\PhpParser\SkippedToken::class, $child, "input: $testCaseFile\r\nexpected: ");
+                    $this->assertNotInstanceOf(\Microsoft\PhpParser\MissingToken::class, $child, "input: $testCaseFile\r\nexpected: ");
+                }
             }
+        } catch (Throwable $e) {
+            $directory = __DIR__ . "/output/$frameworkName/";
+            if (!file_exists($dir = __DIR__ . "/output")) {
+                mkdir($dir);
+            }
+            if (!file_exists($directory)) {
+                mkdir($directory);
+            }
+            $outFile = $directory . basename($testCaseFile);
+            file_put_contents($outFile, $fileContents);
+            throw $e;
         }
 
-        unlink($outFile);
         // echo json_encode($parser->getErrors($sourceFile));
     }
 }


### PR DESCRIPTION
1. We're parsing thousands of files and there are many tokens per file.
   The overhead of all the assert statements is noticeable.
   Optimizing out the check (when they'd pass) speeds this up 3x from 90 seconds to 30 seconds - notably, function calls in php are slow, and phpunit has multiple levels of them
2. Don't write files only to unlink them later.
   Instead, save the failed file only on test suite failure