### PR TITLE
Change getUri return type to nullable string

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -417,7 +417,7 @@ abstract class Node implements \JsonSerializable {
         return $this->getRoot()->fileContents;
     }
 
-    public function getUri() : string {
+    public function getUri() : ?string {
         return $this->getRoot()->uri;
     }
 

--- a/src/Node/SourceFileNode.php
+++ b/src/Node/SourceFileNode.php
@@ -13,7 +13,7 @@ class SourceFileNode extends Node {
     /** @var string */
     public $fileContents;
 
-    /** @var string */
+    /** @var ?string */
     public $uri;
 
     /** @var Node[] */


### PR DESCRIPTION
`Parser::parseSourceFile()` accepts a nullable string $uri. Avoid a potential type error