### PR TITLE
Use PHPDoc `@param string ...$classNames`

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -91,7 +91,7 @@ abstract class Node implements \JsonSerializable {
      * Gets first child that is an instance of one of the provided classes.
      * Returns null if there is no match.
      *
-     * @param array ...$classNames
+     * @param string ...$classNames
      * @return Node|null
      */
     public function getFirstChildNode(...$classNames) {
@@ -117,7 +117,7 @@ abstract class Node implements \JsonSerializable {
      * Gets first descendant node that is an instance of one of the provided classes.
      * Returns null if there is no match.
      *
-     * @param array ...$classNames
+     * @param string ...$classNames
      * @return Node|null
      */
     public function getFirstDescendantNode(...$classNames) {


### PR DESCRIPTION
The `string` is the type of each argument.
The `...` indicates that it is an array of that type, like `function (string ...$classNames)` also would indicate. (for static analyzers parsing that 
(already done elsewhere, e.g. Parser::eat)

```php
    /**
     * Retrieve the current token, and check that it's of the expected TokenKind.
     * If so, advance and return the token. Otherwise return a MissingToken for
     * the expected token.
     * @param int|int[] ...$kinds
     * @return Token
     */
    private function eat(...$kinds) {
        $token = $this->token;
        if (\is_array($kinds[0])) {
            $kinds = $kinds[0];
        }
        foreach ($kinds as $kind) {// ...
```