### PR TITLE
PHPStan Level 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ cache:
     - validation/frameworks
 
 before_script:
-  - if [[ $STATIC_ANALYSIS = true ]]; then composer require phpstan/phpstan --no-update; fi
   - composer install
   - set -e # Stop on first error.
   - phpenv config-rm xdebug.ini || true

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
         "php": ">=7.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.15"
+        "phpunit/phpunit": "^8.5.15",
+        "phpstan/phpstan": "^1.8"
     },
     "license": "MIT",
     "authors": [

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 2
+    level: 3
     paths:
         - src/
     ignoreErrors:

--- a/src/Node.php
+++ b/src/Node.php
@@ -140,6 +140,8 @@ abstract class Node implements \JsonSerializable {
         while ($node->parent !== null) {
             $node = $node->parent;
         }
+
+        /** @var SourceFileNode $node */
         return $node;
     }
 
@@ -613,6 +615,7 @@ abstract class Node implements \JsonSerializable {
             $namespaceDefinition = null;
         }
 
+        /** @var NamespaceDefinition|null $namespaceDefinition */
         return $namespaceDefinition;
     }
 

--- a/src/Node/EnumCaseDeclaration.php
+++ b/src/Node/EnumCaseDeclaration.php
@@ -16,7 +16,7 @@ class EnumCaseDeclaration extends Node {
     /** @var Token */
     public $caseKeyword;
 
-    /** @var QualifiedName */
+    /** @var Token */
     public $name;
 
     /** @var Token|null */

--- a/src/Node/Expression/AssignmentExpression.php
+++ b/src/Node/Expression/AssignmentExpression.php
@@ -11,7 +11,7 @@ use Microsoft\PhpParser\Token;
 
 class AssignmentExpression extends BinaryExpression {
 
-    /** @var Expression */
+    /** @var Expression|Token */
     public $leftOperand;
 
     /** @var Token */

--- a/src/Node/Expression/BinaryExpression.php
+++ b/src/Node/Expression/BinaryExpression.php
@@ -11,13 +11,13 @@ use Microsoft\PhpParser\Token;
 
 class BinaryExpression extends Expression {
 
-    /** @var Expression */
+    /** @var Expression|Token */
     public $leftOperand;
 
     /** @var Token */
     public $operator;
 
-    /** @var Expression */
+    /** @var Expression|Token */
     public $rightOperand;
 
     const CHILD_NAMES = [

--- a/src/Node/Expression/PrefixUpdateExpression.php
+++ b/src/Node/Expression/PrefixUpdateExpression.php
@@ -13,9 +13,6 @@ class PrefixUpdateExpression extends UnaryExpression {
     /** @var Token */
     public $incrementOrDecrementOperator;
 
-    /** @var Variable */
-    public $operand;
-
     const CHILD_NAMES = [
         'incrementOrDecrementOperator',
         'operand'

--- a/src/Node/Expression/SubscriptExpression.php
+++ b/src/Node/Expression/SubscriptExpression.php
@@ -6,6 +6,7 @@
 
 namespace Microsoft\PhpParser\Node\Expression;
 
+use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Node\Expression;
 use Microsoft\PhpParser\Token;
 
@@ -17,7 +18,7 @@ class SubscriptExpression extends Expression {
     /** @var Token */
     public $openBracketOrBrace;
 
-    /** @var Expression */
+    /** @var Expression|MissingToken */
     public $accessExpression;
 
     /** @var Token */

--- a/src/Node/Expression/UnaryExpression.php
+++ b/src/Node/Expression/UnaryExpression.php
@@ -7,9 +7,10 @@
 namespace Microsoft\PhpParser\Node\Expression;
 
 use Microsoft\PhpParser\Node\Expression;
+use Microsoft\PhpParser\Token;
 
 class UnaryExpression extends Expression {
-    /** @var UnaryExpression|Variable */
+    /** @var Expression|Variable|Token */
     public $operand;
 
     const CHILD_NAMES = [

--- a/src/Node/Expression/UnaryOpExpression.php
+++ b/src/Node/Expression/UnaryOpExpression.php
@@ -13,9 +13,6 @@ class UnaryOpExpression extends UnaryExpression {
     /** @var Token */
     public $operator;
 
-    /** @var UnaryExpression */
-    public $operand;
-
     const CHILD_NAMES = [
         'operator',
         'operand'

--- a/src/Node/FunctionReturnType.php
+++ b/src/Node/FunctionReturnType.php
@@ -6,6 +6,7 @@
 
 namespace Microsoft\PhpParser\Node;
 
+use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Token;
 
 trait FunctionReturnType {
@@ -14,6 +15,6 @@ trait FunctionReturnType {
     // TODO: This may be the wrong choice if ?type can ever be mixed with other types in union types
     /** @var Token|null */
     public $questionToken;
-    /** @var DelimitedList\QualifiedNameList|null */
+    /** @var DelimitedList\QualifiedNameList|null|MissingToken */
     public $returnTypeList;
 }

--- a/src/Node/MissingMemberDeclaration.php
+++ b/src/Node/MissingMemberDeclaration.php
@@ -6,6 +6,7 @@
 
 namespace Microsoft\PhpParser\Node;
 
+use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\ModifiedTypeInterface;
 use Microsoft\PhpParser\ModifiedTypeTrait;
 use Microsoft\PhpParser\Node;
@@ -20,7 +21,7 @@ class MissingMemberDeclaration extends Node implements ModifiedTypeInterface {
     /** @var Token|null needed along with typeDeclaration for what looked like typed property declarations but was missing VariableName */
     public $questionToken;
 
-    /** @var DelimitedList\QualifiedNameList|null */
+    /** @var DelimitedList\QualifiedNameList|null|MissingToken */
     public $typeDeclarationList;
 
     const CHILD_NAMES = [

--- a/src/Node/NamespaceUseClause.php
+++ b/src/Node/NamespaceUseClause.php
@@ -6,12 +6,13 @@
 
 namespace Microsoft\PhpParser\Node;
 
+use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Node;
 use Microsoft\PhpParser\Node\DelimitedList;
 use Microsoft\PhpParser\Token;
 
 class NamespaceUseClause extends Node {
-    /** @var QualifiedName */
+    /** @var QualifiedName|MissingToken */
     public $namespaceName;
     /** @var NamespaceAliasingClause */
     public $namespaceAliasingClause;

--- a/src/Node/Statement/InlineHtml.php
+++ b/src/Node/Statement/InlineHtml.php
@@ -20,7 +20,7 @@ class InlineHtml extends StatementNode {
     public $scriptSectionStartTag;
 
     /**
-     * @var ExpressionStatement|null used to represent the expression echoed by `<?=` while parsing.
+     * @var EchoStatement|null used to represent the expression echoed by `<?=` while parsing.
      *
      * This should always be null in the returned AST,
      * and is deliberately excluded from CHILD_NAMES.

--- a/src/Node/Statement/NamespaceDefinition.php
+++ b/src/Node/Statement/NamespaceDefinition.php
@@ -6,6 +6,7 @@
 
 namespace Microsoft\PhpParser\Node\Statement;
 
+use Microsoft\PhpParser\MissingToken;
 use Microsoft\PhpParser\Node\QualifiedName;
 use Microsoft\PhpParser\Node\StatementNode;
 use Microsoft\PhpParser\Token;
@@ -17,7 +18,7 @@ use Microsoft\PhpParser\Node\SourceFileNode;
 class NamespaceDefinition extends StatementNode {
     /** @var Token */
     public $namespaceKeyword;
-    /** @var QualifiedName|null */
+    /** @var QualifiedName|null|MissingToken */
     public $name;
     /** @var CompoundStatementNode|Token */
     public $compoundStatementOrSemicolon;


### PR DESCRIPTION
:wave: in [Phpactor](https://github.com/phpactor/phpactor) one of the most common types of error is accessing a member on NULL on TP parser nodes. So I thought I'd try and increase the type coverage.

This PR:

- Updates PHPStan to level 3.
- Fixes type hints (avoiding refactoring code).
- Adds PHPStan as a dev dependency (it ships as a PHAR now, so no conflicts).
- Removes the overridden public `opeand` property on the children of `UnaryExpression`

As a follow up question is it worth ditching Travis and adding PHPStan to the `main` GHA workflow?

We should be able to get to PHPStan level 5 pretty easy (30 errors) but level 6 is 368 errors :sweat_smile: 