### PR TITLE
Fix regression with getNamespacedName()

### DIFF
--- a/src/NamespacedNameTrait.php
+++ b/src/NamespacedNameTrait.php
@@ -31,7 +31,7 @@ trait NamespacedNameTrait {
             return ResolvedName::buildName($this->getNameParts(), $content);
         }
 
-        if ($namespaceDefinition->name !== null) {
+        if ($namespaceDefinition->name instanceof QualifiedName) {
             $resolvedName = ResolvedName::buildName($namespaceDefinition->name->nameParts, $content);
         } else {
             $resolvedName = ResolvedName::buildName([], $content);


### PR DESCRIPTION
See #390  

This code depended on `name` being NULL but now it seems to be MissingToken cc @TysonAndre 