### PR TITLE
Handle T_ENCAPSED_WHITESPACE as StringLiteral

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1223,6 +1223,7 @@ class Parser {
                 case TokenKind::IntegerLiteralToken:
 
                 case TokenKind::StringLiteralToken:
+                case TokenKind::EncapsedAndWhitespace:
 
                 case TokenKind::SingleQuoteToken:
                 case TokenKind::DoubleQuoteToken:
@@ -1316,6 +1317,7 @@ class Parser {
                 return $this->parseNumericLiteralExpression($parentNode);
 
             case TokenKind::StringLiteralToken:
+            case TokenKind::EncapsedAndWhitespace:
                 return $this->parseStringLiteralExpression($parentNode);
 
             case TokenKind::DoubleQuoteToken:
@@ -2685,7 +2687,7 @@ class Parser {
                     TokenKind::InvalidOctalLiteralToken,
                     TokenKind::InvalidHexadecimalLiteral,
                     TokenKind::InvalidBinaryLiteral,
-                    TokenKind::StringLiteralToken
+                    TokenKind::StringLiteralToken,
                 ); // TODO simplify
 
             return $declareDirective;


### PR DESCRIPTION
Currently the parser interprets the "node" at the offset indicated by `<>`
below as a `SourceFileNode` (or `CompoundStatementNode`:

```
$container->get('foo<>
```

This is because the token is a `T_ENCAPSED_WHITESPACE` token.

I would expect this to be a `StringLiteral`.

This PR changes the behavior to return a `StringLiteral` in this case.
