### PR TITLE
Fix php 8.4 notices about implicitly nullable parameters

### DIFF
--- a/src/Node.php
+++ b/src/Node.php
@@ -151,7 +151,7 @@ abstract class Node implements \JsonSerializable {
      * @param callable|null $shouldDescendIntoChildrenFn
      * @return \Generator|Node[]|Token[]
      */
-    public function getDescendantNodesAndTokens(callable $shouldDescendIntoChildrenFn = null) {
+    public function getDescendantNodesAndTokens(?callable $shouldDescendIntoChildrenFn = null) {
         // TODO - write unit tests to prove invariants
         // (concatenating all descendant Tokens should produce document, concatenating all Nodes should produce document)
         foreach ($this->getChildNodesAndTokens() as $child) {
@@ -176,7 +176,7 @@ abstract class Node implements \JsonSerializable {
      * @param callable|null $shouldDescendIntoChildrenFn
      * @return void
      */
-    public function walkDescendantNodesAndTokens(callable $callback, callable $shouldDescendIntoChildrenFn = null) {
+    public function walkDescendantNodesAndTokens(callable $callback, ?callable $shouldDescendIntoChildrenFn = null) {
         // TODO - write unit tests to prove invariants
         // (concatenating all descendant Tokens should produce document, concatenating all Nodes should produce document)
         foreach (static::CHILD_NAMES as $name) {
@@ -209,7 +209,7 @@ abstract class Node implements \JsonSerializable {
      * @param callable|null $shouldDescendIntoChildrenFn
      * @return \Generator|Node[]
      */
-    public function getDescendantNodes(callable $shouldDescendIntoChildrenFn = null) {
+    public function getDescendantNodes(?callable $shouldDescendIntoChildrenFn = null) {
         foreach ($this->getChildNodes() as $child) {
             yield $child;
             if ($shouldDescendIntoChildrenFn === null || $shouldDescendIntoChildrenFn($child)) {
@@ -223,7 +223,7 @@ abstract class Node implements \JsonSerializable {
      * @param callable|null $shouldDescendIntoChildrenFn
      * @return \Generator|Token[]
      */
-    public function getDescendantTokens(callable $shouldDescendIntoChildrenFn = null) {
+    public function getDescendantTokens(?callable $shouldDescendIntoChildrenFn = null) {
         foreach ($this->getChildNodesAndTokens() as $child) {
             if ($child instanceof Node) {
                 if ($shouldDescendIntoChildrenFn == null || $shouldDescendIntoChildrenFn($child)) {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -175,7 +175,7 @@ class Parser {
      * @param string $fileContents
      * @return SourceFileNode
      */
-    public function parseSourceFile(string $fileContents, string $uri = null) : SourceFileNode {
+    public function parseSourceFile(string $fileContents, ?string $uri = null) : SourceFileNode {
         $this->lexer = $this->makeLexer($fileContents);
 
         $this->reset();
@@ -1417,7 +1417,7 @@ class Parser {
                 case TokenKind::DollarOpenBraceToken:
                 case TokenKind::OpenBraceDollarToken:
                     $expression->children[] = $this->eat(TokenKind::DollarOpenBraceToken, TokenKind::OpenBraceDollarToken);
-                    /** 
+                    /**
                      * @phpstan-ignore-next-line "Strict comparison using
                      * === between 403|404 and 408 will always evaluate to
                      * false" is wrong because those tokens were eaten above

--- a/src/Token.php
+++ b/src/Token.php
@@ -42,7 +42,7 @@ class Token implements \JsonSerializable {
      * @param string|null $document
      * @return bool|null|string
      */
-    public function getText(string $document = null) {
+    public function getText(?string $document = null) {
         if ($document === null) {
             return null;
         }

--- a/tests/LexicalGrammarTest.php
+++ b/tests/LexicalGrammarTest.php
@@ -17,7 +17,7 @@ class LexicalGrammarTest extends TestCase {
     private $expectedTokensFile;
     private $tokens;
     const FILE_PATTERN = __DIR__ . "/cases/lexical/*";
-    public function run(TestResult $result = null) : TestResult {
+    public function run(?TestResult $result = null) : TestResult {
         if (!isset($GLOBALS["GIT_CHECKOUT_LEXER"])) {
             $GLOBALS["GIT_CHECKOUT_LEXER"] = true;
             exec("git -C " . dirname(self::FILE_PATTERN) . " checkout *.php.tokens");

--- a/tests/ParserGrammarTest.php
+++ b/tests/ParserGrammarTest.php
@@ -19,7 +19,7 @@ class ParserGrammarTest extends TestCase {
     private $expectedDiagnosticsFile;
     private $tokens;
     private $diagnostics;
-    public function run(TestResult $result = null) : TestResult {
+    public function run(?TestResult $result = null) : TestResult {
         if (!isset($GLOBALS["GIT_CHECKOUT_PARSER"])) {
             $GLOBALS["GIT_CHECKOUT_PARSER"] = true;
             exec("git -C " . dirname(self::FILE_PATTERN) . " checkout *.php.tree *.php.diag");

--- a/tests/generate_spec_tests.php
+++ b/tests/generate_spec_tests.php
@@ -7,8 +7,8 @@
 
 //$testCases = array('C:\src\php-investigations\tolerant-php-parser\tests\..\php-langspec\tests\traits\traits.phpt');
 $sep = DIRECTORY_SEPARATOR;
-$testCases = glob(__DIR__ . "${sep}..${sep}php-langspec${sep}tests${sep}**${sep}*.phpt");
-$outTestCaseDir = __DIR__ . "${sep}cases${sep}php-langspec${sep}";
+$testCases = glob(__DIR__ . "{$sep}..{$sep}php-langspec{$sep}tests{$sep}**{$sep}*.phpt");
+$outTestCaseDir = __DIR__ . "{$sep}cases{$sep}php-langspec{$sep}";
 mkdir($outTestCaseDir);
 file_put_contents($outTestCaseDir . "README.md", "Auto-generated from php/php-langspec tests");
 


### PR DESCRIPTION
Nullable types were supported since php 7.1, this library requires php >= 7.2, https://wiki.php.net/rfc/deprecate-implicitly-nullable-types deprecates this in php 8.4

And fix notice about deprecated string encapsulation syntax

