### PR TITLE
PHP8.4: Support new without parenthesis

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -3047,7 +3047,8 @@ class Parser {
             $expression instanceof SubscriptExpression ||
             $expression instanceof ScopedPropertyAccessExpression ||
             $expression instanceof StringLiteral ||
-            $expression instanceof ArrayCreationExpression
+            $expression instanceof ArrayCreationExpression ||
+            $expression instanceof ObjectCreationExpression
         )) {
             return $expression;
         }
@@ -3287,6 +3288,11 @@ class Parser {
 
         if ($this->getCurrentToken()->kind === TokenKind::OpenBraceToken) {
             $objectCreationExpression->classMembers = $this->parseClassMembers($objectCreationExpression);
+        }
+
+        // PHP8.4 new with no parenthesis
+        if ($this->getCurrentToken()->kind === TokenKind::ArrowToken) {
+            return $this->parsePostfixExpressionRest($objectCreationExpression);
         }
 
         return $objectCreationExpression;

--- a/tests/cases/parser84/new-without-parenthesis.php
+++ b/tests/cases/parser84/new-without-parenthesis.php
@@ -1,0 +1,3 @@
+<?php
+
+new Foobar()->bar();

--- a/tests/cases/parser84/new-without-parenthesis.php.diag
+++ b/tests/cases/parser84/new-without-parenthesis.php.diag
@@ -1,0 +1,3 @@
+<?php
+
+new Foobar()->bar();

--- a/tests/cases/parser84/new-without-parenthesis.php.tree
+++ b/tests/cases/parser84/new-without-parenthesis.php.tree
@@ -1,0 +1,3 @@
+<?php
+
+new Foobar()->bar();


### PR DESCRIPTION
(from Phpactor's fork - not tested extensively)