### PR TITLE
chore: explicitly declare `ext-tokenizer` as PHP extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "Tolerant PHP-to-AST parser designed for IDE usage scenarios",
     "type": "library",
     "require": {
-        "php": ">=7.2"
+        "php": ">=7.2",
+        "ext-tokenizer": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.15",


### PR DESCRIPTION
This project relies on the [`tokenizer` PHP extension](https://www.php.net/manual/en/book.tokenizer.php), but it is not explicitly declared in `composer.json`. It is assumed to be available in the PHP distribution, which is not always the case. This package makes use of several [`T_*` constants](https://www.php.net/manual/en/tokens.php), which require the `tokenizer` extension. Without it, the following error may occur:

```
Fatal error: Uncaught Error: Undefined constant "Microsoft\PhpParser\T_CLASS_C" in ...
```

This PR adds the missing `ext-tokenizer` requirement to the `require` section.